### PR TITLE
Fixed required arrays when parsing operation variables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.apurebase'
-version '0.4.0'
+version '0.4.1'
 
 buildscript {
     ext.kotlin_version = '1.3.10'

--- a/src/main/kotlin/com/apurebase/kgraphql/request/RequestPreProcessing.kt
+++ b/src/main/kotlin/com/apurebase/kgraphql/request/RequestPreProcessing.kt
@@ -17,8 +17,13 @@ fun tokenizeRequest(input : String) : List<String> {
         when(input[i]){
             in IGNORED_CHARACTERS -> { i++ }
             in OPERANDS -> {
-                tokens.add(input[i].toString())
-                i++
+                if (input.length > i+1 && input.substring(i, i+2) == "]!") {
+                    tokens.add("]!")
+                    i += 2
+                } else {
+                    tokens.add(input[i].toString())
+                    i++
+                }
             }
             '\"' -> {
                 val substring = input.substring(i + 1)
@@ -167,8 +172,8 @@ private fun parseOperationVariables(variablesTokens: List<String>): MutableList<
             }
             variableName == null -> variableName = variableToken
             variableType == null -> variableType = variableToken
-            variableType.startsWith("[") && variableType == "]" -> variableType += variableToken
-            variableType.startsWith("[")  -> variableType += variableToken
+            variableType.startsWith(("[")) && variableToken.startsWith("]") -> variableType += variableToken
+            variableType.startsWith("[") && !variableType.contains("]") -> variableType += variableToken
             defaultTypeStarted && variableDefaultValue == null -> variableDefaultValue = variableToken
             else -> {
                 //if variableName of variableType would be null, it would already be matched

--- a/src/test/kotlin/com/apurebase/kgraphql/TestClasses.kt
+++ b/src/test/kotlin/com/apurebase/kgraphql/TestClasses.kt
@@ -9,6 +9,9 @@ abstract class Person(val name: String, val age: Int)
 
 class Director(name : String, age: Int, val favActors: List<Actor>) : Person(name, age)
 
+class ActorInput(val name: String, val age: Int)
+class ActorCalculateAgeInput(val name: String, val ages: List<Int>)
+
 class Actor(name : String, age: Int) : Person(name, age)
 
 class Id(val literal: String, val numeric: Int)

--- a/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
+++ b/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
@@ -1,17 +1,6 @@
 package com.apurebase.kgraphql.integration
 
-import com.apurebase.kgraphql.Actor
-import com.apurebase.kgraphql.Director
-import com.apurebase.kgraphql.Film
-import com.apurebase.kgraphql.FilmType
-import com.apurebase.kgraphql.Id
-import com.apurebase.kgraphql.IdScalarSupport
-import com.apurebase.kgraphql.Person
-import com.apurebase.kgraphql.Scenario
-import com.apurebase.kgraphql.defaultSchema
-import com.apurebase.kgraphql.deserialize
-import com.apurebase.kgraphql.schema.DefaultSchema
-import com.apurebase.kgraphql.schema.dsl.SchemaBuilder
+import com.apurebase.kgraphql.*
 import org.junit.After
 
 
@@ -180,6 +169,30 @@ abstract class BaseSchemaTest {
             description = "create new actor"
             resolver { name : String, age : Int ->
                 val actor = Actor(name, age)
+                createdActors.add(actor)
+                actor
+            }
+        }
+        mutation("createActorWithInput") {
+            description = "create new actor"
+            resolver { input: ActorInput ->
+                val actor = Actor(input.name, input.age)
+                createdActors.add(actor)
+                actor
+            }
+        }
+        mutation("createActorWithAges") {
+            description = "create new actor"
+            resolver { name: String, ages: List<Int> ->
+                val actor = Actor(name, ages.reduce { sum, age -> sum + age })
+                createdActors.add(actor)
+                actor
+            }
+        }
+        mutation("createActorWithAgesInput") {
+            description = "create new actor"
+            resolver { input: ActorCalculateAgeInput ->
+                val actor = Actor(input.name, input.ages.reduce { sum, age -> sum + age })
                 createdActors.add(actor)
                 actor
             }

--- a/src/test/kotlin/com/apurebase/kgraphql/request/RequestTokenizationTest.kt
+++ b/src/test/kotlin/com/apurebase/kgraphql/request/RequestTokenizationTest.kt
@@ -52,6 +52,43 @@ class RequestTokenizationTest {
     }
 
     @Test
+    fun `Tokenize required list argument`() {
+        val d = "$"
+        testTokenization(
+            input = "mutation create(${d}agesName1: String!, ${d}ages: [String!]!){ createActorWithAges(name: ${d}agesName1, ages: ${d}ages1) { name, age } }",
+            expected = listOf(
+                "mutation",
+                "create",
+                "(",
+                "${d}agesName1",
+                ":",
+                "String!",
+                "${d}ages",
+                ":",
+                "[",
+                "String!",
+                "]!",
+                ")",
+                "{",
+                "createActorWithAges",
+                "(",
+                "name",
+                ":",
+                "${d}agesName1",
+                "ages",
+                ":",
+                "${d}ages1",
+                ")",
+                "{",
+                "name",
+                "age",
+                "}",
+                "}"
+            )
+        )
+    }
+
+    @Test
     fun `tokenize input with quotes`(){
         testTokenization(
                 input = "{hello(name : \"Ted\\\" Mosby\")}",


### PR DESCRIPTION
Defining variables that either have an array or required array, didn't get parsed correctly. This fixes both `$ids: [Int]` and `$ids: [Int!]!`