### PR TITLE
Only allow public properties when building a schema.

### DIFF
--- a/src/main/kotlin/com/apurebase/kgraphql/schema/structure2/SchemaCompilation.kt
+++ b/src/main/kotlin/com/apurebase/kgraphql/schema/structure2/SchemaCompilation.kt
@@ -22,6 +22,7 @@ import com.apurebase.kgraphql.schema.model.TypeDef
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
+import kotlin.reflect.KVisibility
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.isSuperclassOf
 import kotlin.reflect.full.memberProperties
@@ -207,6 +208,7 @@ class SchemaCompilation(
                 { acc, def -> acc + def.transformations.mapKeys { entry -> entry.key.name } })
 
         val kotlinFields = kClass.memberProperties
+                .filter { field -> field.visibility == KVisibility.PUBLIC }
                 .filterNot { field ->  objectDefs.any { it.isIgnored(field.name) } }
                 .map { property -> handleKotlinProperty (
                         kProperty = property,

--- a/src/test/kotlin/com/apurebase/kgraphql/TestClasses.kt
+++ b/src/test/kotlin/com/apurebase/kgraphql/TestClasses.kt
@@ -25,3 +25,5 @@ class IdScalarSupport : StringScalarCoercion<Id> {
 enum class FilmType { FULL_LENGTH, SHORT_LENGTH }
 
 class Scenario(val id : Id, val author : String, val content : String)
+
+class Account(val id : Int, val username : String, private val password: String)

--- a/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
+++ b/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
@@ -5,6 +5,7 @@ import com.apurebase.kgraphql.Context
 import com.apurebase.kgraphql.FilmType
 import com.apurebase.kgraphql.Id
 import com.apurebase.kgraphql.KGraphQL
+import com.apurebase.kgraphql.Account
 import com.apurebase.kgraphql.Scenario
 import com.apurebase.kgraphql.context
 import com.apurebase.kgraphql.defaultSchema
@@ -67,6 +68,27 @@ class SchemaBuilderTest {
                 ?: throw Exception("Scenario type should be present in schema")
         assertThat(scenarioType["author"], nullValue())
         assertThat(scenarioType["content"], notNullValue())
+    }
+
+    @Test
+    fun `ignored invisible properties`() {
+        val testedSchema = defaultSchema {
+            query("account") {
+                resolver { -> Account(42, "AzureDiamond", "hunter2") }
+            }
+        }
+
+        val scenarioType = testedSchema.model.queryTypes[Account::class]
+                ?: throw Exception("Account type should be present in schema")
+
+        // id should exist because it is public
+        assertThat(scenarioType["id"], notNullValue())
+
+        // username should exist because it is public
+        assertThat(scenarioType["username"], notNullValue())
+
+        // password shouldn't exist because it's private
+        assertThat(scenarioType["password"], nullValue())
     }
 
     @Test


### PR DESCRIPTION
This fixes crashes when trying to query private/protected fields.