### PR TITLE
Fix NPE for property resolver using withArgs

### DIFF
--- a/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/PropertyDSL.kt
+++ b/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/PropertyDSL.kt
@@ -9,13 +9,13 @@ import java.lang.IllegalArgumentException
 
 class PropertyDSL<T : Any, R>(val name : String, block : PropertyDSL<T, R>.() -> Unit) : LimitedAccessItemDSL<T>(), ResolverDSL.Target {
 
-    init {
-        block()
-    }
-
     internal lateinit var functionWrapper : FunctionWrapper<R>
 
     private val inputValues = mutableListOf<InputValueDef<*>>()
+
+    init {
+        block()
+    }
 
     private fun resolver(function: FunctionWrapper<R>): ResolverDSL {
         functionWrapper = function

--- a/src/test/kotlin/com/apurebase/kgraphql/specification/language/ArgumentsSpecificationTest.kt
+++ b/src/test/kotlin/com/apurebase/kgraphql/specification/language/ArgumentsSpecificationTest.kt
@@ -101,4 +101,41 @@ class ArgumentsSpecificationTest {
         )))
     }
 
+    @Test
+    fun `property arguments should accept default values`() {
+        val schema = defaultSchema {
+            query("actor") {
+                resolver {
+                    -> Actor("John Doe", age)
+                }
+            }
+
+            type<Actor> {
+                property<String>("greeting") {
+                    resolver { actor: Actor, suffix: String ->
+                        "$suffix, ${actor.name}!"
+                    }.withArgs {
+                        arg<String> { name = "suffix"; defaultValue = "Hello" }
+                    }
+                }
+            }
+        }
+
+        val request = """
+            {
+                actor {
+                    greeting
+                }
+            }
+        """.trimIndent()
+
+        val response = deserialize(schema.execute(request)) as Map<String, Any>
+        assertThat(response, equalTo(mapOf<String, Any>(
+                "data" to mapOf<String, Any>(
+                        "actor" to mapOf<String, Any>(
+                                "greeting" to "Hello, John Doe!"
+                        )
+                )
+        )))
+    }
 }


### PR DESCRIPTION
This pull request fixes a `NullPointerException` thrown if default arguments are specified for a property resolver.  See #43.