### PR TITLE
Fragments validation

### DIFF
--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FragmentsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FragmentsSpecificationTest.kt
@@ -145,4 +145,28 @@ class FragmentsSpecificationTest {
         """)
         } shouldThrow GraphQLError::class withMessage "Fragment spread circular references are not allowed"
     }
+
+    @Test
+    fun `queries with duplicated fragments are denied`() {
+        invoking {
+            BaseTestSchema.execute("""
+            {
+                film {
+                    ...film_title
+                }
+            }
+            
+            fragment film_title on Film {
+                title
+            }
+            
+            fragment film_title on Film {
+                director {
+                    name
+                    age
+                }
+            }
+        """)
+        } shouldThrow GraphQLError::class withMessage "There can be only one fragment named film_title."
+    }
 }


### PR DESCRIPTION
In order to fix the following [issue](https://github.com/aPureBase/KGraphQL/issues/58) we should handle the duplicated fragments scenario.