### PR TITLE
Support for up to 8 types in the prepare DSL block

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/DataLoaderPropertyDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/DataLoaderPropertyDSL.kt
@@ -31,6 +31,34 @@ class DataLoaderPropertyDSL<T, K, R>(
         prepareWrapper = FunctionWrapper.on(block, true)
     }
 
+    fun <E, W> prepare(block: suspend (T, E, W) -> K) {
+        prepareWrapper = FunctionWrapper.on(block, true)
+    }
+
+    fun <E, W, Q> prepare(block: suspend (T, E, W, Q) -> K) {
+        prepareWrapper = FunctionWrapper.on(block, true)
+    }
+
+    fun <E, W, Q, A> prepare(block: suspend (T, E, W, Q, A) -> K) {
+        prepareWrapper = FunctionWrapper.on(block, true)
+    }
+
+    fun <E, W, Q, A, S> prepare(block: suspend (T, E, W, Q, A, S) -> K) {
+        prepareWrapper = FunctionWrapper.on(block, true)
+    }
+
+    fun <E, W, Q, A, S, B> prepare(block: suspend (T, E, W, Q, A, S, B) -> K) {
+        prepareWrapper = FunctionWrapper.on(block, true)
+    }
+
+    fun <E, W, Q, A, S, B, U> prepare(block: suspend (T, E, W, Q, A, S, B, U) -> K) {
+        prepareWrapper = FunctionWrapper.on(block, true)
+    }
+
+    fun <E, W, Q, A, S, B, U, C> prepare(block: suspend (T, E, W, Q, A, S, B, U, C) -> K) {
+        prepareWrapper = FunctionWrapper.on(block, true)
+    }
+
     fun accessRule(rule: (T, Context) -> Exception?){
         val accessRuleAdapter: (T?, Context) -> Exception? = { parent, ctx ->
             if (parent != null) rule(parent, ctx) else IllegalArgumentException("Unexpected null parent of kotlin property")

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/dsl/DataLoaderPropertyDSLTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/dsl/DataLoaderPropertyDSLTest.kt
@@ -17,7 +17,7 @@ class DataLoaderPropertyDSLTest {
                 executor = Executor.DataLoaderPrepared
             }
             query("parent") {
-                resolver { -> Parent("") }
+                resolver { -> Parent() }
             }
             type<Parent> {
                 dataProperty<String, Parent>("child") {
@@ -42,5 +42,5 @@ class DataLoaderPropertyDSLTest {
         results.extract<String>("data/parent/child/data") shouldBeEqualTo "A 1 C 2 E 3 G 4"
     }
 
-    class Parent(val data: String)
+    class Parent(val data: String = "")
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/dsl/DataLoaderPropertyDSLTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/dsl/DataLoaderPropertyDSLTest.kt
@@ -1,0 +1,35 @@
+package com.apurebase.kgraphql.schema.dsl
+
+import com.apurebase.kgraphql.defaultSchema
+import org.junit.Test
+
+class DataLoaderPropertyDSLTest {
+
+    @Test
+    fun `prepare() should support multiple arguments`() {
+        defaultSchema {
+            type<Parent> {
+                dataProperty<Element, Parent>("child") {
+                    prepare { parent, a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H ->
+                        parent + a + b + c + d + e + f + g + h
+                    }
+                }
+            }
+        }
+    }
+
+    abstract class Element {
+        operator fun plus(a: Element): Element {
+            return a
+        }
+    }
+    class Parent : Element()
+    class A : Element()
+    class B : Element()
+    class C : Element()
+    class D : Element()
+    class E : Element()
+    class F : Element()
+    class G : Element()
+    class H : Element()
+}


### PR DESCRIPTION
Fixes #84 
Took the same approach as other DSLs, by just providing same function with different number of type arguments.

Test is mostly to validate future changes, as current state is validated by the compiler.