### PR TITLE
GitHub issue 109

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
@@ -57,12 +57,12 @@ class SchemaCompilation(
     }
 
     suspend fun perform(): DefaultSchema {
-        val queryType = handleQueries()
-        val mutationType = handleMutations()
-        val subscriptionType = handleSubscriptions()
         definition.unions.forEach { handleUnionType(it) }
         definition.objects.forEach { handleObjectType(it.kClass) }
         definition.inputObjects.forEach { handleInputType(it.kClass) }
+        val queryType = handleQueries()
+        val mutationType = handleMutations()
+        val subscriptionType = handleSubscriptions()
 
         queryTypeProxies.forEach { (kClass, typeProxy) ->
             introspectPossibleTypes(kClass, typeProxy)
@@ -198,6 +198,10 @@ class SchemaCompilation(
     }
 
     private suspend fun handleRawType(kClass: KClass<*>, typeCategory: TypeCategory) : Type {
+        when (val type = unions.find { it.name == kClass.simpleName }) {
+            null -> Unit
+            else -> return type
+        }
 
         if(kClass == Context::class) throw SchemaException("Context type cannot be part of schema")
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/github/GitHubIssue109.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/github/GitHubIssue109.kt
@@ -1,0 +1,88 @@
+package com.apurebase.kgraphql.integration.github
+
+import com.apurebase.kgraphql.KGraphQL
+import com.apurebase.kgraphql.objectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.amshove.kluent.`should contain`
+import org.amshove.kluent.should
+import org.amshove.kluent.shouldContain
+import org.junit.jupiter.api.Test
+
+class GitHubIssue109 {
+
+    data class Wrapper(
+        val items: List<QualificationItem>
+    )
+
+    sealed class QualificationItem {
+        data class Qual1(
+            val id: String
+        ) : QualificationItem()
+    }
+
+    @Test
+    fun `Confusion with a list of union type`() {
+        val schema = KGraphQL.schema {
+            unionType<QualificationItem>()
+
+            query("foo") {
+                resolver { ->
+                    Wrapper(listOf(QualificationItem.Qual1("12345")))
+                }
+            }
+        }
+
+        val result = jacksonObjectMapper().readValue<Result>(
+            schema.executeBlocking("""
+                query IntrospectionQuery {
+                    __schema {
+                        types {
+                            name
+                            fields(includeDeprecated: true) {
+                                name
+                                type {
+                                    name
+                                }
+                            }
+                            possibleTypes {
+                                name
+                            }
+                        }
+                    }
+                }
+            """)
+        )
+
+        result.data.__schema.types.shouldContain(
+            Type(
+                name = "QualificationItem",
+                possibleTypes = listOf(
+                    FieldType("Qual1")
+                )
+            )
+        )
+        result.data.__schema.types.shouldContain(
+            Type(
+                name = "Qual1",
+                fields = listOf(
+                    Field(name = "id", type = FieldType())
+                )
+            )
+        )
+    }
+
+    data class Result(val data: Data)
+    data class Data(val __schema: Schema)
+    data class Schema(val types: List<Type>)
+    data class Type(
+        val name: String?,
+        val fields: List<Field>? = null,
+        val possibleTypes: List<FieldType>? = null
+    )
+    data class Field(
+        val name: String?,
+        val type: FieldType
+    )
+    data class FieldType(val name: String? = null)
+}


### PR DESCRIPTION
fixes #109 

In SchemaCompilation#perform, handle the definition's unions, objects and inputObjects before looking at the query, mutation and subscription types.

Then, in SchemaCompilation#handleRawType check if there's already a definition for that type and return early if this is the case, to avoid recreating an existing type.