### PR TITLE
check void returning on resolver

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/operations/AbstractOperationDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/operations/AbstractOperationDSL.kt
@@ -18,6 +18,11 @@ abstract class AbstractOperationDSL(
     internal var functionWrapper: FunctionWrapper<*>? = null
 
     private fun resolver(function: FunctionWrapper<*>): ResolverDSL {
+
+        require(function.hasReturnType()) {
+            "Resolver for $name has no return values"
+        }
+
         functionWrapper = function
         return ResolverDSL(this)
     }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/operations/AbstractOperationDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/operations/AbstractOperationDSL.kt
@@ -20,7 +20,7 @@ abstract class AbstractOperationDSL(
     private fun resolver(function: FunctionWrapper<*>): ResolverDSL {
 
         require(function.hasReturnType()) {
-            "Resolver for $name has no return values"
+            "Resolver for '$name' has no return value"
         }
 
         functionWrapper = function

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/FunctionWrapper.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/FunctionWrapper.kt
@@ -12,6 +12,7 @@ import kotlin.reflect.KType
 import kotlin.reflect.full.callSuspend
 import kotlin.reflect.full.extensionReceiverParameter
 import kotlin.reflect.full.valueParameters
+import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.jvm.reflect
 
 
@@ -474,4 +475,8 @@ interface FunctionWrapper <T> : Publisher {
             }
         }
     }
+
+    fun hasReturnType(): Boolean = getObjectTypeName() != "java.lang.Void" && getObjectTypeName() != "kotlin.Unit"
+
+    private fun getObjectTypeName() = kFunction.returnType.jvmErasure.javaObjectType.name
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
@@ -6,6 +6,10 @@ import com.apurebase.kgraphql.schema.scalar.StringScalarCoercion
 import com.apurebase.kgraphql.schema.structure.Field
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import org.amshove.kluent.invoking
+import org.amshove.kluent.shouldEqual
+import org.amshove.kluent.shouldThrow
+import org.amshove.kluent.with
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
@@ -588,5 +592,18 @@ class SchemaBuilderTest {
         val names = types.map {it["name"]}
         assertThat(names, hasItem("TypeAsInput"))
         assertThat(names, hasItem("TypeAsObject"))
+    }
+
+    @Test
+    fun `Resolver cannot return an Unit value`(){
+        invoking {
+            KGraphQL.schema {
+                query("main") {
+                    resolver { -> Unit }
+                }
+            }
+        } shouldThrow IllegalArgumentException::class with {
+            message shouldEqual "Resolver for main has no return values"
+        }
     }
 }


### PR DESCRIPTION
In order to fix this [issue](https://github.com/aPureBase/KGraphQL/issues/80) I'm thinking to check resolver return value before try to execute a query.
My only concern is about this line: 
`fun hasReturnType(): Boolean = getObjectTypeName() != "java.lang.Void" && getObjectTypeName() != "kotlin.Unit"`

I think there is a better way to valid it.