### PR TITLE
Adds returns function to ResolverDSL to allow generic queries

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/DataLoaderPropertyDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/DataLoaderPropertyDSL.kt
@@ -88,4 +88,8 @@ class DataLoaderPropertyDSL<T, K, R>(
         this.inputValues.addAll(inputValues)
     }
 
+    override fun setReturnType(type: KType) {
+        // NOOP
+    }
+
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/PropertyDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/PropertyDSL.kt
@@ -5,6 +5,7 @@ import com.apurebase.kgraphql.schema.model.FunctionWrapper
 import com.apurebase.kgraphql.schema.model.InputValueDef
 import com.apurebase.kgraphql.schema.model.PropertyDef
 import java.lang.IllegalArgumentException
+import kotlin.reflect.KType
 
 
 class PropertyDSL<T : Any, R>(val name : String, block : PropertyDSL<T, R>.() -> Unit) : LimitedAccessItemDSL<T>(), ResolverDSL.Target {
@@ -61,5 +62,9 @@ class PropertyDSL<T : Any, R>(val name : String, block : PropertyDSL<T, R>.() ->
 
     override fun addInputValues(inputValues: Collection<InputValueDef<*>>) {
         this.inputValues.addAll(inputValues)
+    }
+
+    override fun setReturnType(type: KType) {
+        // NOOP
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/ResolverDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/ResolverDSL.kt
@@ -2,9 +2,10 @@ package com.apurebase.kgraphql.schema.dsl
 
 import com.apurebase.kgraphql.schema.dsl.types.InputValuesDSL
 import com.apurebase.kgraphql.schema.model.InputValueDef
+import kotlin.reflect.*
 
 
-class ResolverDSL(private val target: Target) {
+class ResolverDSL(val target: Target) {
     fun withArgs(block : InputValuesDSL.() -> Unit){
         val inputValuesDSL = InputValuesDSL().apply(block)
 
@@ -13,7 +14,14 @@ class ResolverDSL(private val target: Target) {
         })
     }
 
+    @OptIn(ExperimentalStdlibApi::class)
+    inline fun <reified T: Any> returns(): ResolverDSL {
+        target.setReturnType(typeOf<T>())
+        return this
+    }
+
     interface Target {
         fun addInputValues(inputValues: Collection<InputValueDef<*>>)
+        fun setReturnType(type: KType)
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/UnionPropertyDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/UnionPropertyDSL.kt
@@ -6,6 +6,7 @@ import com.apurebase.kgraphql.schema.model.InputValueDef
 import com.apurebase.kgraphql.schema.model.PropertyDef
 import com.apurebase.kgraphql.schema.model.TypeDef
 import java.lang.IllegalArgumentException
+import kotlin.reflect.KType
 
 
 class UnionPropertyDSL<T : Any>(val name : String, block: UnionPropertyDSL<T>.() -> Unit) : LimitedAccessItemDSL<T>(), ResolverDSL.Target {
@@ -68,5 +69,9 @@ class UnionPropertyDSL<T : Any>(val name : String, block: UnionPropertyDSL<T>.()
 
     override fun addInputValues(inputValues: Collection<InputValueDef<*>>) {
         this.inputValues.addAll(inputValues)
+    }
+
+    override fun setReturnType(type: KType) {
+        throw IllegalArgumentException("A return value cannot be set on an Union type")
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/operations/AbstractOperationDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/operations/AbstractOperationDSL.kt
@@ -6,6 +6,7 @@ import com.apurebase.kgraphql.schema.dsl.ResolverDSL
 import com.apurebase.kgraphql.schema.model.FunctionWrapper
 import com.apurebase.kgraphql.schema.model.InputValueDef
 import kotlin.reflect.KFunction
+import kotlin.reflect.KType
 
 
 abstract class AbstractOperationDSL(
@@ -17,10 +18,18 @@ abstract class AbstractOperationDSL(
 
     internal var functionWrapper: FunctionWrapper<*>? = null
 
+    var explicitReturnType: KType? = null
+
     private fun resolver(function: FunctionWrapper<*>): ResolverDSL {
 
-        require(function.hasReturnType()) {
-            "Resolver for '$name' has no return value"
+        try {
+            require(function.hasReturnType()) {
+                "Resolver for '$name' has no return value"
+            }
+        } catch (e: Throwable) {
+            if ("KotlinReflectionInternalError" !in e.toString()) {
+                throw e
+            }
         }
 
         functionWrapper = function
@@ -58,5 +67,8 @@ abstract class AbstractOperationDSL(
         this.inputValues.addAll(inputValues)
     }
 
+    override fun setReturnType(type: KType) {
+        explicitReturnType = type
+    }
 
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/operations/MutationDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/operations/MutationDSL.kt
@@ -18,7 +18,8 @@ class MutationDSL(
             isDeprecated = isDeprecated,
             deprecationReason = deprecationReason,
             inputValues = inputValues,
-            accessRule = accessRuleBlock
+            accessRule = accessRuleBlock,
+            explicitReturnType = explicitReturnType
         )
     }
 

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/operations/QueryDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/operations/QueryDSL.kt
@@ -18,7 +18,8 @@ class QueryDSL(
             isDeprecated = isDeprecated,
             deprecationReason = deprecationReason,
             inputValues = inputValues,
-            accessRule = accessRuleBlock
+            accessRule = accessRuleBlock,
+            explicitReturnType = explicitReturnType
         )
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/BaseOperationDef.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/BaseOperationDef.kt
@@ -1,10 +1,16 @@
 package com.apurebase.kgraphql.schema.model
 
 import com.apurebase.kgraphql.Context
+import kotlin.reflect.KType
 
 abstract class BaseOperationDef<T, R>(
         name : String,
         private val operationWrapper: FunctionWrapper<R>,
         val inputValues : List<InputValueDef<*>>,
-        val accessRule : ((T?, Context) -> Exception?)?
-) : Definition(name), OperationDef<R>, FunctionWrapper<R> by operationWrapper
+        val accessRule : ((T?, Context) -> Exception?)?,
+        private val explicitReturnType: KType?
+) : Definition(name), OperationDef<R>, FunctionWrapper<R> by operationWrapper {
+
+        val returnType: KType get() = explicitReturnType ?: kFunction.returnType
+
+}

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/MutationDef.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/MutationDef.kt
@@ -1,6 +1,7 @@
 package com.apurebase.kgraphql.schema.model
 
 import com.apurebase.kgraphql.Context
+import kotlin.reflect.KType
 
 class MutationDef<R> (
         name : String,
@@ -9,5 +10,6 @@ class MutationDef<R> (
         override val isDeprecated: Boolean,
         override val deprecationReason: String?,
         accessRule: ((Nothing?, Context) -> Exception?)? = null,
-        inputValues : List<InputValueDef<*>> = emptyList()
-) : BaseOperationDef<Nothing, R>(name, resolver, inputValues, accessRule), DescribedDef
+        inputValues : List<InputValueDef<*>> = emptyList(),
+        explicitReturnType: KType? = null
+) : BaseOperationDef<Nothing, R>(name, resolver, inputValues, accessRule, explicitReturnType), DescribedDef

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/PropertyDef.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/PropertyDef.kt
@@ -18,8 +18,9 @@ interface PropertyDef<T> : Depreciable, DescribedDef {
             override val isDeprecated: Boolean = false,
             override val deprecationReason: String? = null,
             accessRule : ((T?, Context) -> Exception?)? = null,
-            inputValues : List<InputValueDef<*>> = emptyList()
-    ) : BaseOperationDef<T, R>(name, resolver, inputValues, accessRule), PropertyDef<T>
+            inputValues : List<InputValueDef<*>> = emptyList(),
+            explicitReturnType: KType? = null
+    ) : BaseOperationDef<T, R>(name, resolver, inputValues, accessRule, explicitReturnType), PropertyDef<T>
 
     /**
      * [T] -> The Parent Type

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/QueryDef.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/QueryDef.kt
@@ -1,6 +1,7 @@
 package com.apurebase.kgraphql.schema.model
 
 import com.apurebase.kgraphql.Context
+import kotlin.reflect.KType
 
 class QueryDef<R> (
         name : String,
@@ -9,5 +10,6 @@ class QueryDef<R> (
         override val isDeprecated: Boolean = false,
         override val deprecationReason: String? = null,
         accessRule: ((Nothing?, Context) -> Exception?)? = null,
-        inputValues : List<InputValueDef<*>> = emptyList()
-) : BaseOperationDef<Nothing, R>(name, resolver, inputValues, accessRule), DescribedDef
+        inputValues : List<InputValueDef<*>> = emptyList(),
+        explicitReturnType: KType? = null
+) : BaseOperationDef<Nothing, R>(name, resolver, inputValues, accessRule, explicitReturnType), DescribedDef

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/SubscriptionDef.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/SubscriptionDef.kt
@@ -1,6 +1,7 @@
 package com.apurebase.kgraphql.schema.model
 
 import com.apurebase.kgraphql.Context
+import kotlin.reflect.KType
 
 class SubscriptionDef<R> (
         name : String,
@@ -9,5 +10,6 @@ class SubscriptionDef<R> (
         override val isDeprecated: Boolean,
         override val deprecationReason: String?,
         accessRule: ((Nothing?, Context) -> Exception?)? = null,
-        inputValues : List<InputValueDef<*>> = emptyList()
-) : BaseOperationDef<Nothing, R>(name, resolver, inputValues, accessRule), DescribedDef
+        inputValues : List<InputValueDef<*>> = emptyList(),
+        explicitReturnType: KType? = null
+) : BaseOperationDef<Nothing, R>(name, resolver, inputValues, accessRule, explicitReturnType), DescribedDef

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
@@ -175,7 +175,7 @@ class SchemaCompilation(
         }
     } catch (e: Throwable) {
         if ("KotlinReflectionInternalError" in e.toString()) {
-            throw SchemaException("If you construct a query/mutation generically, you must specify the return type T explicitly with either resolver{ }.returns<T> or resolver{ }.returnsListOf<T>()")
+            throw SchemaException("If you construct a query/mutation generically, you must specify the return type T explicitly with resolver{ ... }.returns<T>()")
         } else {
             throw e
         }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
@@ -612,7 +612,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    fun `specifying return value explicitly allows generic query creation`(){
+    fun `specifying return type explicitly allows generic query creation`(){
         val schema = defaultSchema {
             createGenericQuery(InputOne("generic"))
         }
@@ -633,12 +633,12 @@ class SchemaBuilderTest {
                 createGenericQueryWithoutReturns(InputOne("generic"))
             }
         } shouldThrow SchemaException::class with {
-            message shouldBeEqualTo "If you construct a query/mutation generically, you must specify the return type T explicitly with either resolver{ }.returns<T> or resolver{ }.returnsListOf<T>()"
+            message shouldBeEqualTo "If you construct a query/mutation generically, you must specify the return type T explicitly with resolver{ ... }.returns<T>()"
         }
     }
 
     @Test
-    fun `specifying returnsListOf explicitly allows generic query creation that returns lists`(){
+    fun `specifying return type explicitly allows generic query creation that returns List of T`(){
         val schema = defaultSchema {
             createGenericQuery(listOf("generic"))
         }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
@@ -1,6 +1,7 @@
 package com.apurebase.kgraphql.schema
 
 import com.apurebase.kgraphql.*
+import com.apurebase.kgraphql.schema.dsl.SchemaBuilder
 import com.apurebase.kgraphql.schema.introspection.TypeKind
 import com.apurebase.kgraphql.schema.scalar.StringScalarCoercion
 import com.apurebase.kgraphql.schema.structure.Field
@@ -602,5 +603,46 @@ class SchemaBuilderTest {
         } shouldThrow IllegalArgumentException::class with {
             message shouldBeEqualTo "Resolver for 'main' has no return value"
         }
+    }
+
+    inline fun <reified T: Any> SchemaBuilder.createGenericQuery(x: T) {
+        query("data") {
+            resolver { -> x }.returns<T>()
+        }
+    }
+
+    @Test
+    fun `specifying return value explicitly allows generic query creation`(){
+        val schema = defaultSchema {
+            createGenericQuery(InputOne("generic"))
+        }
+
+        assertThat(schema.typeByKClass(InputOne::class), notNullValue())
+    }
+
+    inline fun <reified T: Any> SchemaBuilder.createGenericQueryWithoutReturns(x: T) {
+        query("data") {
+            resolver { -> x }
+        }
+    }
+
+    @Test
+    fun `not specifying return value explicitly with generic query creation throws exception`(){
+        invoking {
+            defaultSchema {
+                createGenericQueryWithoutReturns(InputOne("generic"))
+            }
+        } shouldThrow SchemaException::class with {
+            message shouldBeEqualTo "If you construct a query/mutation generically, you must specify the return type T explicitly with either resolver{ }.returns<T> or resolver{ }.returnsListOf<T>()"
+        }
+    }
+
+    @Test
+    fun `specifying returnsListOf explicitly allows generic query creation that returns lists`(){
+        val schema = defaultSchema {
+            createGenericQuery(listOf("generic"))
+        }
+        val result = deserialize(schema.executeBlocking("{data}"))
+        assertThat(result.extract("data/data"), equalTo(listOf("generic")))
     }
 }


### PR DESCRIPTION
The pull request proposes some changes I introduced to implement the functionality I mentioned in issue #139 .

The changes don't break any of the existing code, however I touched upon a couple of files and I am not super satisfied with the outcome. Ie. I need to catch some internal Kotlin reflection exceptions to prevent the checks for a valid return type from failing early in the resolver construction. Because I will supply the expected return type explicitly in a secondary call in the ResolverDSL, similar to the withArgs. The explicit type resolution works similar to the DataLoaderProperty. Also, I had to add another method to the Target interface in the ResolverDSL which has the unfortunate side effect that there are now some methods in some of the other subclasses, where those function currently do nothing, because I didn't see the need for the generic support there (might be useful there as well though).

The code works now as I envisioned as can be shown in the tests I added. However, I am not 100% sure if the code is really merge ready. Nonetheless I hope this pull request is still somewhat helpful.