### PR TITLE
Use correct KType when custom InputValue is provided

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
@@ -332,8 +332,9 @@ class SchemaCompilation(
         }
 
         return operation.argumentsDescriptor.map { (name, kType) ->
-            val kqlInput = inputValues.find { it.name == name } ?: InputValueDef(kType.jvmErasure, name)
-            val inputType = handlePossiblyWrappedType(kType, TypeCategory.INPUT)
+            val inputValue = inputValues.find { it.name == name }
+            val kqlInput = inputValue ?: InputValueDef(kType.jvmErasure, name)
+            val inputType = handlePossiblyWrappedType(inputValue?.kClass?.starProjectedType ?: kType, TypeCategory.INPUT)
             InputValue(kqlInput, inputType)
         }
     }


### PR DESCRIPTION
When a custom InputTypeDef is provided, the kqlInput is correctly set, but the inputType is not.

Due to kotlins reflection behaviour, which returns functions with generic types instead of the underlying types, overriding the input type seems mandatory. [https://youtrack.jetbrains.com/issue/KT-42746](https://youtrack.jetbrains.com/issue/KT-42746)
Doing so enables the use of generics discussed in #139 

Example:
```
inline fun <reified T : Any, reified U : Any, V: UseCase<T, U>> SchemaBuilder.connection(usecase: V) {
    query(usecase::class.simpleName!!) {
        resolver { request: T, ctx: Context ->
            usecase.execute(request, ctx.get<User>())
        }.returns<U>().apply {
            addInputValues(listOf(InputValueDef(T::class, "request")))
        }
    }
}
```
