### PR TITLE
adding support to render error responses per the graphql spec, closes #68

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/Extensions.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/Extensions.kt
@@ -1,8 +1,11 @@
 package com.apurebase.kgraphql
 
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
-import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
 import kotlin.reflect.KType
@@ -13,9 +16,9 @@ internal fun <T : Any> KClass<T>.defaultKQLTypeName() = this.simpleName!!
 
 internal fun KType.defaultKQLTypeName() = this.jvmErasure.defaultKQLTypeName()
 
-internal fun String.dropQuotes() : String = if(isLiteral()) drop(1).dropLast(1) else this
+internal fun String.dropQuotes(): String = if (isLiteral()) drop(1).dropLast(1) else this
 
-internal fun String.isLiteral() : Boolean = startsWith('\"') && endsWith('\"')
+internal fun String.isLiteral(): Boolean = startsWith('\"') && endsWith('\"')
 
 internal fun KParameter.isNullable() = type.isMarkedNullable
 
@@ -32,7 +35,6 @@ internal fun KType.getIterableElementType(): KType? {
 
 
 internal fun not(boolean: Boolean) = !boolean
-
 
 
 internal suspend fun <T, R> Collection<T>.toMapAsync(

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/configuration/SchemaConfiguration.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/configuration/SchemaConfiguration.kt
@@ -1,5 +1,6 @@
 package com.apurebase.kgraphql.configuration
 
+import com.apurebase.kgraphql.schema.execution.ErrorFunction
 import com.apurebase.kgraphql.schema.execution.Executor
 import com.fasterxml.jackson.databind.ObjectMapper
 import kotlinx.coroutines.CoroutineDispatcher
@@ -19,7 +20,8 @@ data class SchemaConfiguration(
 
         val executor: Executor,
         val timeout: Long?,
-        val plugins: MutableMap<KClass<*>, Any>
+        val plugins: MutableMap<KClass<*>, Any>,
+        val errorFunction: ErrorFunction
 ) {
         @Suppress("UNCHECKED_CAST")
         operator fun <T: Any> get(type: KClass<T>) = plugins[type] as T?

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/SchemaConfigurationDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/SchemaConfigurationDSL.kt
@@ -1,11 +1,13 @@
 package com.apurebase.kgraphql.schema.dsl
 
 import com.apurebase.kgraphql.configuration.PluginConfiguration
+import com.apurebase.kgraphql.configuration.SchemaConfiguration
+import com.apurebase.kgraphql.schema.execution.DefaultErrorFunction
+import com.apurebase.kgraphql.schema.execution.ErrorFunction
+import com.apurebase.kgraphql.schema.execution.Executor
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.apurebase.kgraphql.configuration.SchemaConfiguration
-import com.apurebase.kgraphql.schema.execution.Executor
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlin.reflect.KClass
@@ -20,6 +22,7 @@ open class SchemaConfigurationDSL {
     var wrapErrors: Boolean = true
     var executor: Executor = Executor.Parallel
     var timeout: Long? = null
+    var errorFunction: ErrorFunction = DefaultErrorFunction()
 
     private val plugins: MutableMap<KClass<*>, Any> = mutableMapOf()
 
@@ -42,7 +45,9 @@ open class SchemaConfigurationDSL {
             wrapErrors,
             executor,
             timeout,
-            plugins
+            plugins,
+            errorFunction
         )
     }
+
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ErrorResult.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ErrorResult.kt
@@ -1,0 +1,60 @@
+package com.apurebase.kgraphql.schema.execution
+
+import com.apurebase.kgraphql.GraphQLError
+import com.apurebase.kgraphql.schema.model.ast.SelectionNode
+
+data class ErrorResult(
+    val message: String = "",
+    val path: List<Any> = listOf(),
+    val locations: List<Pair<Int, Int>> = listOf(),
+    val extensions: Map<String, Any>? = mapOf()
+)
+
+interface ErrorFunction {
+    fun errorMessageFunction(node: Execution.Node, e: GraphQLError): String
+    fun errorPathFunction(node: Execution.Node, e: GraphQLError): List<Any>
+    fun errorLocationsFunction(node: Execution.Node, e: GraphQLError): List<Pair<Int, Int>>
+    fun errorExtensionsFunction(node: Execution.Node, e: GraphQLError): Map<String, Any>?
+}
+
+class DefaultErrorFunction : ErrorFunction {
+
+    override fun errorMessageFunction(node: Execution.Node, e: GraphQLError): String {
+        return if (e.originalError?.message.isNullOrBlank().not()) {
+            e.originalError?.message.orEmpty()
+        } else if (e.cause?.message.isNullOrBlank().not()) {
+            e.cause?.message.orEmpty()
+        } else {
+            ""
+        }
+    }
+
+    override fun errorPathFunction(node: Execution.Node, e: GraphQLError): List<Any> {
+        return e.nodes?.flatMap { n ->
+            when(n) {
+                is SelectionNode -> {
+                    n.fullPath.split("\\.").map {
+                        try {
+                            it.toInt()
+                        } catch (e: NumberFormatException) {
+                            it
+                        }
+                    }
+                }
+                else -> {
+                    listOf(n.loc?.source?.name.orEmpty())
+                }
+            }
+        }.orEmpty()
+    }
+
+    override fun errorLocationsFunction(node: Execution.Node, e: GraphQLError): List<Pair<Int, Int>> {
+        return e.locations?.map {
+            Pair(it.line, it.column)
+        }.orEmpty()
+    }
+
+    override fun errorExtensionsFunction(node: Execution.Node, e: GraphQLError): Map<String, Any>? {
+        return null
+    }
+}


### PR DESCRIPTION
adding support to render error responses per the graphql spec, closes #68

Need some guidance on:

* handling edge cases for default error response rendering
* adding tests to assert this works correctly for queries and mutations