### PR TITLE
InputValue KType

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # KGraphQL version
-version=0.17.11
+version=0.17.12-SNAPSHOT
 
 # Dependencies
 coroutine_version=1.5.0

--- a/kgraphql/build.gradle.kts
+++ b/kgraphql/build.gradle.kts
@@ -76,50 +76,50 @@ val dokkaJar by tasks.creating(Jar::class) {
     from(tasks.dokkaHtml)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            artifactId = project.name
-            from(components["java"])
-            artifact(sourcesJar)
-            artifact(dokkaJar)
-            pom {
-                name.set("KGraphQL")
-                description.set("KGraphQL is a Kotlin implementation of GraphQL. It provides a rich DSL to set up the GraphQL schema.")
-                url.set("https://kgraphql.io/")
-                organization {
-                    name.set("aPureBase")
-                    url.set("http://apurebase.com/")
-                }
-                licenses {
-                    license {
-                        name.set("MIT License")
-                        url.set("https://github.com/aPureBase/KGraphQL/blob/main/LICENSE.md")
-                    }
-                }
-                developers {
-                    developer {
-                        id.set("jeggy")
-                        name.set("Jógvan Olsen")
-                        email.set("jol@apurebase.com")
-                    }
-                }
-                scm {
-                    connection.set("scm:git:https://github.com/aPureBase/KGraphQL.git")
-                    developerConnection.set("scm:git:https://github.com/aPureBase/KGraphQL.git")
-                    url.set("https://github.com/aPureBase/KGraphQL/")
-                    tag.set("HEAD")
-                }
-            }
-        }
-    }
-}
-
-signing {
-    isRequired = isReleaseVersion
-    useInMemoryPgpKeys(
-        System.getenv("ORG_GRADLE_PROJECT_signingKey"),
-        System.getenv("ORG_GRADLE_PROJECT_signingPassword")
-    )
-    sign(publishing.publications["maven"])
-}
+//publishing {
+//    publications {
+//        create<MavenPublication>("maven") {
+//            artifactId = project.name
+//            from(components["java"])
+//            artifact(sourcesJar)
+//            artifact(dokkaJar)
+//            pom {
+//                name.set("KGraphQL")
+//                description.set("KGraphQL is a Kotlin implementation of GraphQL. It provides a rich DSL to set up the GraphQL schema.")
+//                url.set("https://kgraphql.io/")
+//                organization {
+//                    name.set("aPureBase")
+//                    url.set("http://apurebase.com/")
+//                }
+//                licenses {
+//                    license {
+//                        name.set("MIT License")
+//                        url.set("https://github.com/aPureBase/KGraphQL/blob/main/LICENSE.md")
+//                    }
+//                }
+//                developers {
+//                    developer {
+//                        id.set("jeggy")
+//                        name.set("Jógvan Olsen")
+//                        email.set("jol@apurebase.com")
+//                    }
+//                }
+//                scm {
+//                    connection.set("scm:git:https://github.com/aPureBase/KGraphQL.git")
+//                    developerConnection.set("scm:git:https://github.com/aPureBase/KGraphQL.git")
+//                    url.set("https://github.com/aPureBase/KGraphQL/")
+//                    tag.set("HEAD")
+//                }
+//            }
+//        }
+//    }
+//}
+//
+//signing {
+//    isRequired = isReleaseVersion
+//    useInMemoryPgpKeys(
+//        System.getenv("ORG_GRADLE_PROJECT_signingKey"),
+//        System.getenv("ORG_GRADLE_PROJECT_signingPassword")
+//    )
+//    sign(publishing.publications["maven"])
+//}

--- a/kgraphql/build.gradle.kts
+++ b/kgraphql/build.gradle.kts
@@ -76,50 +76,50 @@ val dokkaJar by tasks.creating(Jar::class) {
     from(tasks.dokkaHtml)
 }
 
-//publishing {
-//    publications {
-//        create<MavenPublication>("maven") {
-//            artifactId = project.name
-//            from(components["java"])
-//            artifact(sourcesJar)
-//            artifact(dokkaJar)
-//            pom {
-//                name.set("KGraphQL")
-//                description.set("KGraphQL is a Kotlin implementation of GraphQL. It provides a rich DSL to set up the GraphQL schema.")
-//                url.set("https://kgraphql.io/")
-//                organization {
-//                    name.set("aPureBase")
-//                    url.set("http://apurebase.com/")
-//                }
-//                licenses {
-//                    license {
-//                        name.set("MIT License")
-//                        url.set("https://github.com/aPureBase/KGraphQL/blob/main/LICENSE.md")
-//                    }
-//                }
-//                developers {
-//                    developer {
-//                        id.set("jeggy")
-//                        name.set("Jógvan Olsen")
-//                        email.set("jol@apurebase.com")
-//                    }
-//                }
-//                scm {
-//                    connection.set("scm:git:https://github.com/aPureBase/KGraphQL.git")
-//                    developerConnection.set("scm:git:https://github.com/aPureBase/KGraphQL.git")
-//                    url.set("https://github.com/aPureBase/KGraphQL/")
-//                    tag.set("HEAD")
-//                }
-//            }
-//        }
-//    }
-//}
-//
-//signing {
-//    isRequired = isReleaseVersion
-//    useInMemoryPgpKeys(
-//        System.getenv("ORG_GRADLE_PROJECT_signingKey"),
-//        System.getenv("ORG_GRADLE_PROJECT_signingPassword")
-//    )
-//    sign(publishing.publications["maven"])
-//}
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            artifactId = project.name
+            from(components["java"])
+            artifact(sourcesJar)
+            artifact(dokkaJar)
+            pom {
+                name.set("KGraphQL")
+                description.set("KGraphQL is a Kotlin implementation of GraphQL. It provides a rich DSL to set up the GraphQL schema.")
+                url.set("https://kgraphql.io/")
+                organization {
+                    name.set("aPureBase")
+                    url.set("http://apurebase.com/")
+                }
+                licenses {
+                    license {
+                        name.set("MIT License")
+                        url.set("https://github.com/aPureBase/KGraphQL/blob/main/LICENSE.md")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("jeggy")
+                        name.set("Jógvan Olsen")
+                        email.set("jol@apurebase.com")
+                    }
+                }
+                scm {
+                    connection.set("scm:git:https://github.com/aPureBase/KGraphQL.git")
+                    developerConnection.set("scm:git:https://github.com/aPureBase/KGraphQL.git")
+                    url.set("https://github.com/aPureBase/KGraphQL/")
+                    tag.set("HEAD")
+                }
+            }
+        }
+    }
+}
+
+signing {
+    isRequired = isReleaseVersion
+    useInMemoryPgpKeys(
+        System.getenv("ORG_GRADLE_PROJECT_signingKey"),
+        System.getenv("ORG_GRADLE_PROJECT_signingPassword")
+    )
+    sign(publishing.publications["maven"])
+}

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/InputValueDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/InputValueDSL.kt
@@ -3,9 +3,10 @@ package com.apurebase.kgraphql.schema.dsl.types
 import com.apurebase.kgraphql.schema.dsl.DepreciableItemDSL
 import com.apurebase.kgraphql.schema.model.InputValueDef
 import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 
-class InputValueDSL<T : Any>(val kClass: KClass<T>) : DepreciableItemDSL() {
+class InputValueDSL<T : Any>(val kClass: KClass<T>, val kType: KType? = null) : DepreciableItemDSL() {
 
     lateinit var name : String
 
@@ -17,6 +18,7 @@ class InputValueDSL<T : Any>(val kClass: KClass<T>) : DepreciableItemDSL() {
             defaultValue = defaultValue,
             isDeprecated = isDeprecated,
             description = description,
-            deprecationReason = deprecationReason
+            deprecationReason = deprecationReason,
+            kType = kType
     )
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/InputValuesDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/InputValuesDSL.kt
@@ -1,19 +1,21 @@
 package com.apurebase.kgraphql.schema.dsl.types
 
 import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 
 class InputValuesDSL {
 
     val inputValues = mutableListOf<InputValueDSL<*>>()
 
-
-    fun <T : Any> arg(kClass: KClass<T>, block : InputValueDSL<T>.() -> Unit){
-        inputValues.add(InputValueDSL(kClass).apply(block))
+    fun <T : Any> arg(kClass: KClass<T>, kType: KType? = null, block : InputValueDSL<T>.() -> Unit){
+        inputValues.add(InputValueDSL(kClass, kType).apply(block))
     }
 
+    @OptIn(ExperimentalStdlibApi::class)
     inline fun <reified T : Any> arg(noinline block : InputValueDSL<T>.() -> Unit){
-        arg(T::class, block)
+        arg(T::class, typeOf<T>(), block)
     }
 
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/InputValueDef.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/InputValueDef.kt
@@ -1,6 +1,7 @@
 package com.apurebase.kgraphql.schema.model
 
 import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 
 class InputValueDef<T : Any>(
@@ -9,5 +10,6 @@ class InputValueDef<T : Any>(
         val defaultValue : T? = null,
         override val isDeprecated: Boolean = false,
         override val description: String? = null,
-        override val deprecationReason: String? = null
+        override val deprecationReason: String? = null,
+        val kType : KType? = null
 ) : DescribedDef, Depreciable

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
@@ -332,8 +332,9 @@ class SchemaCompilation(
         }
 
         return operation.argumentsDescriptor.map { (name, kType) ->
-            val kqlInput = inputValues.find { it.name == name } ?: InputValueDef(kType.jvmErasure, name)
-            val inputType = handlePossiblyWrappedType(kType, TypeCategory.INPUT)
+            val inputValue = inputValues.find { it.name == name }
+            val kqlInput = inputValue ?: InputValueDef(kType.jvmErasure, name)
+            val inputType = handlePossiblyWrappedType(inputValue?.kType ?: kType, TypeCategory.INPUT)
             InputValue(kqlInput, inputType)
         }
     }


### PR DESCRIPTION
In order to support generic input types discussed in #143, and overcome the jvm erasure issue discussed in #144, kType is added to inputValue.

The code does compile, tests do run, however, whenever I build and use it in my application, it does compile but I get java.lang.NoSuchMethodErrors when trying to invoke these altered methods.

I can't seem to figure out whether it's a caching issue on my side or something else.
Could you take a look?