### PR TITLE
Added support for differentiating between null and undefined

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
@@ -40,8 +40,17 @@ open class ArgumentTransformer(val schema : DefaultSchema) {
                         ?: throw GraphQLError("Something went wrong while searching for the constructor parameter type : '${valueField.name.value}'", value)
 
                     params.getValue(valueField.name.value) to transformValue(paramType, valueField.value, variables)
-                }.toMap()
+                }.toMap().toMutableMap()
 
+                // transform optional values
+                for (param in params.values) {
+                    if (param.type.jvmErasure == OptionalValue::class) {
+                        if (param in valueMap)
+                            valueMap[param] = OptionalValue.Defined(valueMap[param])
+                        else valueMap[param] = OptionalValue.Undefined
+                    }
+                }
+                
                 val missingNonOptionalInputs = params.values
                         .filter { !it.isOptional && !valueMap.containsKey(it) }
 

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentsHandler.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentsHandler.kt
@@ -34,7 +34,7 @@ internal class ArgumentsHandler(schema : DefaultSchema) : ArgumentTransformer(sc
         return inputValues.map { parameter ->
             val value = args?.get(parameter.name)
 
-            when {
+            val transformedValue = when {
                 //inject request context
                 parameter.type.isInstance(requestContext) -> requestContext
                 parameter.type.isInstance(executionNode) -> executionNode
@@ -64,6 +64,11 @@ internal class ArgumentsHandler(schema : DefaultSchema) : ArgumentTransformer(sc
                     transformedValue
                 }
             }
+            if (parameter.isOptionalValue)
+                if (args != null && parameter.name in args)
+                    OptionalValue.Defined(transformedValue)
+                else OptionalValue.Undefined
+            else transformedValue
         }
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/OptionalValue.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/OptionalValue.kt
@@ -1,0 +1,6 @@
+package com.apurebase.kgraphql.schema.execution
+
+sealed class OptionalValue<out T: Any> {
+  data class Defined<T: Any>(val value: T?): OptionalValue<T>()
+  object Undefined: OptionalValue<Nothing>()
+}

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/InputValue.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/InputValue.kt
@@ -8,7 +8,8 @@ class InputValue<T : Any>(
         valueDef: InputValueDef<T>,
         override val type: Type,
         //TODO: Replace with GraphQL compliant representation
-        override val defaultValue: String? = valueDef.defaultValue?.toString()
+        override val defaultValue: String? = valueDef.defaultValue?.toString(),
+        val isOptionalValue: Boolean
 ) : __InputValue {
 
     override val name: String = valueDef.name

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/TestClasses.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/TestClasses.kt
@@ -1,5 +1,6 @@
 package com.apurebase.kgraphql
 
+import com.apurebase.kgraphql.schema.execution.OptionalValue
 import com.apurebase.kgraphql.schema.model.ast.ValueNode
 import com.apurebase.kgraphql.schema.scalar.StringScalarCoercion
 
@@ -28,3 +29,10 @@ enum class FilmType { FULL_LENGTH, SHORT_LENGTH }
 class Scenario(val id : Id, val author : String, val content : String)
 
 class Account(val id : Int, val username : String, private val password: String)
+
+
+data class UserFilter(
+    val name: OptionalValue<String>,
+    val email: OptionalValue<String>,
+    val isMale: OptionalValue<Boolean>,
+)

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
@@ -1,6 +1,7 @@
 package com.apurebase.kgraphql.integration
 
 import com.apurebase.kgraphql.*
+import com.apurebase.kgraphql.schema.execution.OptionalValue
 import org.junit.jupiter.api.AfterEach
 import java.io.ByteArrayInputStream
 
@@ -140,6 +141,29 @@ abstract class BaseSchemaTest {
             description = "returns little of big number"
             resolver { big : Boolean -> if(big) 10000 else 0 }
         }
+        query("search") {
+            description = "returns list of results"
+            resolver { filter: OptionalValue<String> ->
+                val values = listOf("foo", "bar", "baz")
+                if (filter is OptionalValue.Defined) {
+                    filter.value?.let { filterValue ->
+                        values.filter { it.contains(filterValue) }
+                    } ?: emptyList()
+                } else values
+            }
+        }
+        query("searchUsers") {
+            fun OptionalValue<Any>.str() = if (this is OptionalValue.Defined)
+                value.toString() ?: "null"
+            else "undefined" 
+                resolver { filter: UserFilter ->
+                    listOf(
+                        filter.name.str(),
+                        filter.email.str(),
+                        filter.isMale.str()
+                    )
+                }
+            }
         query("film") {
             description = "mock film"
             resolver { -> prestige }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/QueryTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/QueryTest.kt
@@ -1,7 +1,6 @@
 package com.apurebase.kgraphql.integration
 
 import com.apurebase.kgraphql.*
-import com.apurebase.kgraphql.GraphQLError
 import com.apurebase.kgraphql.helpers.getFields
 import com.apurebase.kgraphql.schema.execution.Execution
 import org.amshove.kluent.*
@@ -69,6 +68,29 @@ class QueryTest : BaseSchemaTest() {
         val map = execute("{filmByRank(rank: 2){title}}")
         assertNoErrors(map)
         assertThat(map.extract<String>("data/filmByRank/title"), equalTo("Se7en"))
+    }
+
+    @Test
+    fun `query with optional argument`(){
+        var map = execute("{search}")
+        assertNoErrors(map)
+        assertThat(map.extract<List<String>>("data/search"), equalTo(listOf("foo", "bar", "baz")))
+        map = execute("{search(filter: \"ba\")}")
+        assertNoErrors(map)
+        assertThat(map.extract<List<String>>("data/search"), equalTo(listOf("bar", "baz")))
+    }
+
+    @Test
+    fun `query with optional input field`(){
+        mapOf(
+            "{}" to listOf("undefined", "undefined", "undefined"),
+            "{name: null}" to listOf("null", "undefined", "undefined"),
+            """{name: "tim", email:"gmail.com", isMale:true}""" to listOf("tim", "gmail.com", "true")
+        ).forEach { (filter, results) ->
+            val map = execute("{searchUsers(filter:$filter)}")
+            assertNoErrors(map)
+            assertThat(map.extract<List<String>>("data/searchUsers"), equalTo(results))
+        }
     }
 
     @Test

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
@@ -2,6 +2,7 @@ package com.apurebase.kgraphql.schema
 
 import com.apurebase.kgraphql.*
 import com.apurebase.kgraphql.schema.dsl.SchemaBuilder
+import com.apurebase.kgraphql.schema.execution.OptionalValue
 import com.apurebase.kgraphql.schema.introspection.TypeKind
 import com.apurebase.kgraphql.schema.scalar.StringScalarCoercion
 import com.apurebase.kgraphql.schema.structure.Field
@@ -335,6 +336,51 @@ class SchemaBuilderTest {
 
         val introspection = deserialize(schema.executeBlocking("{__schema{queryType{fields{name, args{name, description, defaultValue}}}}}"))
         assertThat(introspection.extract<String>("data/__schema/queryType/fields[0]/args[0]/description"), equalTo(expectedDescription))
+    }
+    
+    @Test
+    fun `OptionalValue can be for argument type`() {
+        val values = listOf("foo", "bar", "baz")
+        val schema = defaultSchema { 
+            query("data") {
+                resolver { filter: OptionalValue<String> ->
+                    when (filter) {
+                        is OptionalValue.Defined -> filter.value?.let { values.filter { it1 -> it.contains(it1) } } ?: emptyList()
+                        OptionalValue.Undefined -> values
+                    }
+                }
+            }
+        }
+        val filterArg = schema.queryType.fields?.find { it.name == "data" }?.args?.find { it.name == "filter" }
+        assertThat(filterArg?.type?.name, equalTo("String"))
+    }
+
+    @Test
+    @Suppress("UNUSED_ANONYMOUS_PARAMETER")
+    fun `input fields can be optional`() {
+        val schema = defaultSchema {
+            query("search") {
+                resolver { filter: UserFilter ->
+                    ""
+                }
+            }
+        }
+        val filterArg = schema.queryType.fields?.find { it.name == "search" }?.args?.find { it.name == "filter" }
+        assertThat(filterArg, notNullValue())
+        val nonNullFilterType = filterArg!!.type
+        assertThat(nonNullFilterType.kind, equalTo(TypeKind.NON_NULL))
+        val filterType = nonNullFilterType.ofType
+        assertThat(filterType, notNullValue())
+        assertThat(filterType!!.name, equalTo("UserFilter"))
+        assertThat(filterType.kind, equalTo(TypeKind.INPUT_OBJECT))
+        val nameArg = filterType.inputFields?.find { it.name == "name" }
+        assertThat(nameArg, notNullValue())
+        assertThat(nameArg!!.type.kind, equalTo(TypeKind.SCALAR))
+        assertThat(nameArg.type.name, equalTo("String"))
+        val isMaleArg = filterType.inputFields?.find { it.name == "isMale" }
+        assertThat(isMaleArg, notNullValue())
+        assertThat(isMaleArg!!.type.kind, equalTo(TypeKind.SCALAR))
+        assertThat(isMaleArg.type.name, equalTo("Boolean"))
     }
 
     @Test


### PR DESCRIPTION
This propoosal address the issue raised here: #103 
This commit introduces a OptionalValue<T> class which can either be OptionalValue.Defined<T>(value: T?) or OptionalValue.Undefined.
If an argument / input field has this type it is considered an optional T
This works for my own use cases. I hope this can be helpful


