### PR TITLE
add configuration to disable instrospection

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/configuration/SchemaConfiguration.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/configuration/SchemaConfiguration.kt
@@ -19,6 +19,7 @@ data class SchemaConfiguration(
 
         val executor: Executor,
         val timeout: Long?,
+        val introspection: Boolean = true,
         val plugins: MutableMap<KClass<*>, Any>
 ) {
         @Suppress("UNCHECKED_CAST")

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/DefaultSchema.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/DefaultSchema.kt
@@ -44,6 +44,10 @@ class DefaultSchema (
             ?.let { VariablesJson.Defined(configuration.objectMapper, variables) }
             ?: VariablesJson.Empty()
 
+        if (!configuration.introspection && request.isIntrospection()) {
+            throw GraphQLError("GraphQL introspection is not allowed")
+        }
+
         val document = Parser(request).parseDocument()
 
         val executor = options.executor?.let(this@DefaultSchema::getExecutor) ?: defaultRequestExecutor
@@ -54,6 +58,8 @@ class DefaultSchema (
             context = context
         )
     }
+
+    private fun String.isIntrospection() = this.contains("__schema") || this.contains("__type")
 
     override fun typeByKClass(kClass: KClass<*>): Type? = model.queryTypes[kClass]
 

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/SchemaConfigurationDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/SchemaConfigurationDSL.kt
@@ -20,6 +20,7 @@ open class SchemaConfigurationDSL {
     var wrapErrors: Boolean = true
     var executor: Executor = Executor.Parallel
     var timeout: Long? = null
+    var introspection: Boolean = true
 
     private val plugins: MutableMap<KClass<*>, Any> = mutableMapOf()
 
@@ -42,6 +43,7 @@ open class SchemaConfigurationDSL {
             wrapErrors,
             executor,
             timeout,
+            introspection,
             plugins
         )
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
@@ -338,6 +338,28 @@ class SchemaBuilderTest {
     }
 
     @Test
+    fun `introspections query should be disabled`(){
+        val expectedDescription = "Int Argument"
+        val expectedDefaultValue = 33
+        val schema = defaultSchema {
+
+            configure {
+                introspection = false
+            }
+
+            query("data"){
+                resolver { int: Int -> int }.withArgs {
+                    arg <Int> { name = "int"; defaultValue = expectedDefaultValue; description = expectedDescription }
+                }
+            }
+        }
+
+        expect<GraphQLError> {
+            schema.executeBlocking("{__schema{queryType{fields{name, args{name, description, defaultValue}}}}}")
+        }
+    }
+
+    @Test
     @Suppress("UNUSED_ANONYMOUS_PARAMETER")
     fun `arg name must match exactly one of type property`(){
         expect<SchemaException>("Invalid input values on data: [intss]") {


### PR DESCRIPTION
In order to improve security I think we should be able to disable introspection via configuration.

[GraphQL Introspection](https://graphql.org/learn/introspection/)
[GraphQL Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html)