### PR TITLE
Increase query resolver's function arguments: 9 to 19

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/operations/AbstractOperationDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/operations/AbstractOperationDSL.kt
@@ -58,6 +58,26 @@ abstract class AbstractOperationDSL(
 
     fun <T, R, E, W, Q, A, S, B, U, C> resolver(function: suspend (R, E, W, Q, A, S, B, U, C) -> T) = resolver(FunctionWrapper.on(function))
 
+    fun <T, R, E, W, Q, A, S, B, U, C, D> resolver(function: suspend (R, E, W, Q, A, S, B, U, C, D) -> T) = resolver(FunctionWrapper.on(function))
+
+    fun <T, R, E, W, Q, A, S, B, U, C, D, F> resolver(function: suspend (R, E, W, Q, A, S, B, U, C, D, F) -> T) = resolver(FunctionWrapper.on(function))
+
+    fun <T, R, E, W, Q, A, S, B, U, C, D, F, G> resolver(function: suspend (R, E, W, Q, A, S, B, U, C, D, F, G) -> T) = resolver(FunctionWrapper.on(function))
+
+    fun <T, R, E, W, Q, A, S, B, U, C, D, F, G, H> resolver(function: suspend (R, E, W, Q, A, S, B, U, C, D, F, G, H) -> T) = resolver(FunctionWrapper.on(function))
+
+    fun <T, R, E, W, Q, A, S, B, U, C, D, F, G, H, I> resolver(function: suspend (R, E, W, Q, A, S, B, U, C, D, F, G, H, I) -> T) = resolver(FunctionWrapper.on(function))
+
+    fun <T, R, E, W, Q, A, S, B, U, C, D, F, G, H, I, J> resolver(function: suspend (R, E, W, Q, A, S, B, U, C, D, F, G, H, I, J) -> T) = resolver(FunctionWrapper.on(function))
+
+    fun <T, R, E, W, Q, A, S, B, U, C, D, F, G, H, I, J, K> resolver(function: suspend (R, E, W, Q, A, S, B, U, C, D, F, G, H, I, J, K) -> T) = resolver(FunctionWrapper.on(function))
+
+    fun <T, R, E, W, Q, A, S, B, U, C, D, F, G, H, I, J, K, L> resolver(function: suspend (R, E, W, Q, A, S, B, U, C, D, F, G, H, I, J, K, L) -> T) = resolver(FunctionWrapper.on(function))
+
+    fun <T, R, E, W, Q, A, S, B, U, C, D, F, G, H, I, J, K, L, M> resolver(function: suspend (R, E, W, Q, A, S, B, U, C, D, F, G, H, I, J, K, L, M) -> T) = resolver(FunctionWrapper.on(function))
+
+    fun <T, R, E, W, Q, A, S, B, U, C, D, F, G, H, I, J, K, L, M, N> resolver(function: suspend (R, E, W, Q, A, S, B, U, C, D, F, G, H, I, J, K, L, M, N) -> T) = resolver(FunctionWrapper.on(function))
+
     fun accessRule(rule: (Context) -> Exception?){
         val accessRuleAdapter: (Nothing?, Context) -> Exception? = { _, ctx -> rule(ctx) }
         this.accessRuleBlock = accessRuleAdapter

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/FunctionWrapper.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/FunctionWrapper.kt
@@ -62,6 +62,35 @@ interface FunctionWrapper <T> : Publisher {
         fun <T, R, E, W, Q, A, S, G, H, J> on (function : suspend (R, E, W, Q, A, S, G, H, J) -> T, hasReceiver: Boolean = false)
             = ArityNine(function, hasReceiver)
 
+        fun <T, R, E, W, Q, A, S, G, H, J, K> on (function : suspend (R, E, W, Q, A, S, G, H, J, K) -> T, hasReceiver: Boolean = false)
+                = ArityTen(function, hasReceiver)
+
+        fun <T, R, E, W, Q, A, S, G, H, J, K, L> on (function : suspend (R, E, W, Q, A, S, G, H, J, K, L) -> T, hasReceiver: Boolean = false)
+                = ArityEleven(function, hasReceiver)
+
+        fun <T, R, E, W, Q, A, S, G, H, J, K, L, M> on (function : suspend (R, E, W, Q, A, S, G, H, J, K, L, M) -> T, hasReceiver: Boolean = false)
+                = ArityTwelve(function, hasReceiver)
+
+        fun <T, R, E, W, Q, A, S, G, H, J, K, L, M, N> on (function : suspend (R, E, W, Q, A, S, G, H, J, K, L, M, N) -> T, hasReceiver: Boolean = false)
+                = ArityThirteen(function, hasReceiver)
+
+        fun <T, R, E, W, Q, A, S, G, H, J, K, L, M, N, O> on (function : suspend (R, E, W, Q, A, S, G, H, J, K, L, M, N, O) -> T, hasReceiver: Boolean = false)
+                = ArityFourteen(function, hasReceiver)
+
+        fun <T, R, E, W, Q, A, S, G, H, J, K, L, M, N, O, P> on (function : suspend (R, E, W, Q, A, S, G, H, J, K, L, M, N, O, P) -> T, hasReceiver: Boolean = false)
+                = ArityFifteen(function, hasReceiver)
+
+        fun <T, R, E, W, Q, A, S, G, H, J, K, L, M, N, O, P, U> on (function : suspend (R, E, W, Q, A, S, G, H, J, K, L, M, N, O, P, U) -> T, hasReceiver: Boolean = false)
+                = AritySixteen(function, hasReceiver)
+
+        fun <T, R, E, W, Q, A, S, G, H, J, K, L, M, N, O, P, U, V> on (function : suspend (R, E, W, Q, A, S, G, H, J, K, L, M, N, O, P, U, V) -> T, hasReceiver: Boolean = false)
+                = AritySeventeen(function, hasReceiver)
+
+        fun <T, R, E, W, Q, A, S, G, H, J, K, L, M, N, O, P, U, V, X> on (function : suspend (R, E, W, Q, A, S, G, H, J, K, L, M, N, O, P, U, V, X) -> T, hasReceiver: Boolean = false)
+                = ArityEighteen(function, hasReceiver)
+
+        fun <T, R, E, W, Q, A, S, G, H, J, K, L, M, N, O, P, U, V, X, Y> on (function : suspend (R, E, W, Q, A, S, G, H, J, K, L, M, N, O, P, U, V, X, Y) -> T, hasReceiver: Boolean = false)
+                = ArityNineteen(function, hasReceiver)
     }
 
     val kFunction: KFunction<T>
@@ -488,6 +517,366 @@ interface FunctionWrapper <T> : Publisher {
         override suspend fun invoke(vararg args: Any?): T? {
             if(args.size == arity()){
                 val t = implementation(args[0] as R, args[1] as E, args[2] as W, args[3] as Q, args[4] as A, args[5] as S, args[6] as D, args[7] as F, args[8] as G)
+                subscribers.forEach{
+                    it.value?.onNext(t)
+                }
+                return t
+            } else {
+                val e = IllegalArgumentException("This function needs exactly ${arity()} arguments")
+                subscribers.forEach{
+                    it.value?.onError(e)
+                }
+                throw e
+            }
+        }
+    }
+
+    class ArityTen<T, R, E, W, Q, A, S, D, F, G, H>(
+        val implementation : suspend (R, E, W, Q, A, S, D, F, G, H)-> T, override val hasReceiver: Boolean
+    ) : Base<T>() {
+        override fun unsubscribe(subscription: String) {
+            subscribers.remove(subscription)
+        }
+        override suspend fun invoke(args: List<Any?>, subscriptionArgs: List<String>, objectWriter: ObjectWriter): T? {
+            TODO("not needed")
+        }
+        override fun subscribe(subscription: String, subscriber: Subscriber) {
+            subscribers[subscription] = subscriber
+        }
+
+        override val kFunction: KFunction<T>
+            @Synchronized
+            get() = implementation.reflect()!!
+
+        override fun arity(): Int = 9
+
+        override suspend fun invoke(vararg args: Any?): T? {
+            if(args.size == arity()){
+                val t = implementation(args[0] as R, args[1] as E, args[2] as W, args[3] as Q, args[4] as A, args[5] as S, args[6] as D, args[7] as F, args[8] as G, args[9] as H)
+                subscribers.forEach{
+                    it.value?.onNext(t)
+                }
+                return t
+            } else {
+                val e = IllegalArgumentException("This function needs exactly ${arity()} arguments")
+                subscribers.forEach{
+                    it.value?.onError(e)
+                }
+                throw e
+            }
+        }
+    }
+
+    class ArityEleven<T, R, E, W, Q, A, S, D, F, G, H, I>(
+        val implementation : suspend (R, E, W, Q, A, S, D, F, G, H, I)-> T, override val hasReceiver: Boolean
+    ) : Base<T>() {
+        override fun unsubscribe(subscription: String) {
+            subscribers.remove(subscription)
+        }
+        override suspend fun invoke(args: List<Any?>, subscriptionArgs: List<String>, objectWriter: ObjectWriter): T? {
+            TODO("not needed")
+        }
+        override fun subscribe(subscription: String, subscriber: Subscriber) {
+            subscribers[subscription] = subscriber
+        }
+
+        override val kFunction: KFunction<T>
+            @Synchronized
+            get() = implementation.reflect()!!
+
+        override fun arity(): Int = 9
+
+        override suspend fun invoke(vararg args: Any?): T? {
+            if(args.size == arity()){
+                val t = implementation(args[0] as R, args[1] as E, args[2] as W, args[3] as Q, args[4] as A, args[5] as S, args[6] as D, args[7] as F, args[8] as G, args[9] as H, args[10] as I)
+                subscribers.forEach{
+                    it.value?.onNext(t)
+                }
+                return t
+            } else {
+                val e = IllegalArgumentException("This function needs exactly ${arity()} arguments")
+                subscribers.forEach{
+                    it.value?.onError(e)
+                }
+                throw e
+            }
+        }
+    }
+
+    class ArityTwelve<T, R, E, W, Q, A, S, D, F, G, H, I, J>(
+        val implementation : suspend (R, E, W, Q, A, S, D, F, G, H, I, J)-> T, override val hasReceiver: Boolean
+    ) : Base<T>() {
+        override fun unsubscribe(subscription: String) {
+            subscribers.remove(subscription)
+        }
+        override suspend fun invoke(args: List<Any?>, subscriptionArgs: List<String>, objectWriter: ObjectWriter): T? {
+            TODO("not needed")
+        }
+        override fun subscribe(subscription: String, subscriber: Subscriber) {
+            subscribers[subscription] = subscriber
+        }
+
+        override val kFunction: KFunction<T>
+            @Synchronized
+            get() = implementation.reflect()!!
+
+        override fun arity(): Int = 9
+
+        override suspend fun invoke(vararg args: Any?): T? {
+            if(args.size == arity()){
+                val t = implementation(args[0] as R, args[1] as E, args[2] as W, args[3] as Q, args[4] as A, args[5] as S, args[6] as D, args[7] as F, args[8] as G, args[9] as H, args[10] as I, args[11] as J)
+                subscribers.forEach{
+                    it.value?.onNext(t)
+                }
+                return t
+            } else {
+                val e = IllegalArgumentException("This function needs exactly ${arity()} arguments")
+                subscribers.forEach{
+                    it.value?.onError(e)
+                }
+                throw e
+            }
+        }
+    }
+
+    class ArityThirteen<T, R, E, W, Q, A, S, D, F, G, H, I, J, K>(
+        val implementation : suspend (R, E, W, Q, A, S, D, F, G, H, I, J, K)-> T, override val hasReceiver: Boolean
+    ) : Base<T>() {
+        override fun unsubscribe(subscription: String) {
+            subscribers.remove(subscription)
+        }
+        override suspend fun invoke(args: List<Any?>, subscriptionArgs: List<String>, objectWriter: ObjectWriter): T? {
+            TODO("not needed")
+        }
+        override fun subscribe(subscription: String, subscriber: Subscriber) {
+            subscribers[subscription] = subscriber
+        }
+
+        override val kFunction: KFunction<T>
+            @Synchronized
+            get() = implementation.reflect()!!
+
+        override fun arity(): Int = 9
+
+        override suspend fun invoke(vararg args: Any?): T? {
+            if(args.size == arity()){
+                val t = implementation(args[0] as R, args[1] as E, args[2] as W, args[3] as Q, args[4] as A, args[5] as S, args[6] as D, args[7] as F, args[8] as G, args[9] as H, args[10] as I, args[11] as J, args[12] as K)
+                subscribers.forEach{
+                    it.value?.onNext(t)
+                }
+                return t
+            } else {
+                val e = IllegalArgumentException("This function needs exactly ${arity()} arguments")
+                subscribers.forEach{
+                    it.value?.onError(e)
+                }
+                throw e
+            }
+        }
+    }
+
+    class ArityFourteen<T, R, E, W, Q, A, S, D, F, G, H, I, J, K, L>(
+        val implementation : suspend (R, E, W, Q, A, S, D, F, G, H, I, J, K, L)-> T, override val hasReceiver: Boolean
+    ) : Base<T>() {
+        override fun unsubscribe(subscription: String) {
+            subscribers.remove(subscription)
+        }
+        override suspend fun invoke(args: List<Any?>, subscriptionArgs: List<String>, objectWriter: ObjectWriter): T? {
+            TODO("not needed")
+        }
+        override fun subscribe(subscription: String, subscriber: Subscriber) {
+            subscribers[subscription] = subscriber
+        }
+
+        override val kFunction: KFunction<T>
+            @Synchronized
+            get() = implementation.reflect()!!
+
+        override fun arity(): Int = 9
+
+        override suspend fun invoke(vararg args: Any?): T? {
+            if(args.size == arity()){
+                val t = implementation(args[0] as R, args[1] as E, args[2] as W, args[3] as Q, args[4] as A, args[5] as S, args[6] as D, args[7] as F, args[8] as G, args[9] as H, args[10] as I, args[11] as J, args[12] as K, args[13] as L)
+                subscribers.forEach{
+                    it.value?.onNext(t)
+                }
+                return t
+            } else {
+                val e = IllegalArgumentException("This function needs exactly ${arity()} arguments")
+                subscribers.forEach{
+                    it.value?.onError(e)
+                }
+                throw e
+            }
+        }
+    }
+
+    class ArityFifteen<T, R, E, W, Q, A, S, D, F, G, H, I, J, K, L, M>(
+        val implementation : suspend (R, E, W, Q, A, S, D, F, G, H, I, J, K, L, M)-> T, override val hasReceiver: Boolean
+    ) : Base<T>() {
+        override fun unsubscribe(subscription: String) {
+            subscribers.remove(subscription)
+        }
+        override suspend fun invoke(args: List<Any?>, subscriptionArgs: List<String>, objectWriter: ObjectWriter): T? {
+            TODO("not needed")
+        }
+        override fun subscribe(subscription: String, subscriber: Subscriber) {
+            subscribers[subscription] = subscriber
+        }
+
+        override val kFunction: KFunction<T>
+            @Synchronized
+            get() = implementation.reflect()!!
+
+        override fun arity(): Int = 9
+
+        override suspend fun invoke(vararg args: Any?): T? {
+            if(args.size == arity()){
+                val t = implementation(args[0] as R, args[1] as E, args[2] as W, args[3] as Q, args[4] as A, args[5] as S, args[6] as D, args[7] as F, args[8] as G, args[9] as H, args[10] as I, args[11] as J, args[12] as K, args[13] as L, args[14] as M)
+                subscribers.forEach{
+                    it.value?.onNext(t)
+                }
+                return t
+            } else {
+                val e = IllegalArgumentException("This function needs exactly ${arity()} arguments")
+                subscribers.forEach{
+                    it.value?.onError(e)
+                }
+                throw e
+            }
+        }
+    }
+
+    class AritySixteen<T, R, E, W, Q, A, S, D, F, G, H, I, J, K, L, M, N>(
+        val implementation : suspend (R, E, W, Q, A, S, D, F, G, H, I, J, K, L, M, N)-> T, override val hasReceiver: Boolean
+    ) : Base<T>() {
+        override fun unsubscribe(subscription: String) {
+            subscribers.remove(subscription)
+        }
+        override suspend fun invoke(args: List<Any?>, subscriptionArgs: List<String>, objectWriter: ObjectWriter): T? {
+            TODO("not needed")
+        }
+        override fun subscribe(subscription: String, subscriber: Subscriber) {
+            subscribers[subscription] = subscriber
+        }
+
+        override val kFunction: KFunction<T>
+            @Synchronized
+            get() = implementation.reflect()!!
+
+        override fun arity(): Int = 9
+
+        override suspend fun invoke(vararg args: Any?): T? {
+            if(args.size == arity()){
+                val t = implementation(args[0] as R, args[1] as E, args[2] as W, args[3] as Q, args[4] as A, args[5] as S, args[6] as D, args[7] as F, args[8] as G, args[9] as H, args[10] as I, args[11] as J, args[12] as K, args[13] as L, args[14] as M, args[15] as N)
+                subscribers.forEach{
+                    it.value?.onNext(t)
+                }
+                return t
+            } else {
+                val e = IllegalArgumentException("This function needs exactly ${arity()} arguments")
+                subscribers.forEach{
+                    it.value?.onError(e)
+                }
+                throw e
+            }
+        }
+    }
+
+    class AritySeventeen<T, R, E, W, Q, A, S, D, F, G, H, I, J, K, L, M, N, O>(
+        val implementation : suspend (R, E, W, Q, A, S, D, F, G, H, I, J, K, L, M, N, O)-> T, override val hasReceiver: Boolean
+    ) : Base<T>() {
+        override fun unsubscribe(subscription: String) {
+            subscribers.remove(subscription)
+        }
+        override suspend fun invoke(args: List<Any?>, subscriptionArgs: List<String>, objectWriter: ObjectWriter): T? {
+            TODO("not needed")
+        }
+        override fun subscribe(subscription: String, subscriber: Subscriber) {
+            subscribers[subscription] = subscriber
+        }
+
+        override val kFunction: KFunction<T>
+            @Synchronized
+            get() = implementation.reflect()!!
+
+        override fun arity(): Int = 9
+
+        override suspend fun invoke(vararg args: Any?): T? {
+            if(args.size == arity()){
+                val t = implementation(args[0] as R, args[1] as E, args[2] as W, args[3] as Q, args[4] as A, args[5] as S, args[6] as D, args[7] as F, args[8] as G, args[9] as H, args[10] as I, args[11] as J, args[12] as K, args[13] as L, args[14] as M, args[15] as N, args[16] as O)
+                subscribers.forEach{
+                    it.value?.onNext(t)
+                }
+                return t
+            } else {
+                val e = IllegalArgumentException("This function needs exactly ${arity()} arguments")
+                subscribers.forEach{
+                    it.value?.onError(e)
+                }
+                throw e
+            }
+        }
+    }
+
+    class ArityEighteen<T, R, E, W, Q, A, S, D, F, G, H, I, J, K, L, M, N, O, P>(
+        val implementation : suspend (R, E, W, Q, A, S, D, F, G, H, I, J, K, L, M, N, O, P)-> T, override val hasReceiver: Boolean
+    ) : Base<T>() {
+        override fun unsubscribe(subscription: String) {
+            subscribers.remove(subscription)
+        }
+        override suspend fun invoke(args: List<Any?>, subscriptionArgs: List<String>, objectWriter: ObjectWriter): T? {
+            TODO("not needed")
+        }
+        override fun subscribe(subscription: String, subscriber: Subscriber) {
+            subscribers[subscription] = subscriber
+        }
+
+        override val kFunction: KFunction<T>
+            @Synchronized
+            get() = implementation.reflect()!!
+
+        override fun arity(): Int = 9
+
+        override suspend fun invoke(vararg args: Any?): T? {
+            if(args.size == arity()){
+                val t = implementation(args[0] as R, args[1] as E, args[2] as W, args[3] as Q, args[4] as A, args[5] as S, args[6] as D, args[7] as F, args[8] as G, args[9] as H, args[10] as I, args[11] as J, args[12] as K, args[13] as L, args[14] as M, args[15] as N, args[16] as O, args[17] as P)
+                subscribers.forEach{
+                    it.value?.onNext(t)
+                }
+                return t
+            } else {
+                val e = IllegalArgumentException("This function needs exactly ${arity()} arguments")
+                subscribers.forEach{
+                    it.value?.onError(e)
+                }
+                throw e
+            }
+        }
+    }
+
+    class ArityNineteen<T, R, E, W, Q, A, S, D, F, G, H, I, J, K, L, M, N, O, P, U>(
+        val implementation : suspend (R, E, W, Q, A, S, D, F, G, H, I, J, K, L, M, N, O, P, U)-> T, override val hasReceiver: Boolean
+    ) : Base<T>() {
+        override fun unsubscribe(subscription: String) {
+            subscribers.remove(subscription)
+        }
+        override suspend fun invoke(args: List<Any?>, subscriptionArgs: List<String>, objectWriter: ObjectWriter): T? {
+            TODO("not needed")
+        }
+        override fun subscribe(subscription: String, subscriber: Subscriber) {
+            subscribers[subscription] = subscriber
+        }
+
+        override val kFunction: KFunction<T>
+            @Synchronized
+            get() = implementation.reflect()!!
+
+        override fun arity(): Int = 9
+
+        override suspend fun invoke(vararg args: Any?): T? {
+            if(args.size == arity()){
+                val t = implementation(args[0] as R, args[1] as E, args[2] as W, args[3] as Q, args[4] as A, args[5] as S, args[6] as D, args[7] as F, args[8] as G, args[9] as H, args[10] as I, args[11] as J, args[12] as K, args[13] as L, args[14] as M, args[15] as N, args[16] as O, args[17] as P, args[18] as U)
                 subscribers.forEach{
                     it.value?.onNext(t)
                 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/FunctionWrapper.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/FunctionWrapper.kt
@@ -27,70 +27,70 @@ interface FunctionWrapper <T> : Publisher {
     //lots of boilerplate here, because kotlin-reflect doesn't support invoking lambdas, local and anonymous functions yet
     companion object {
         fun <T> on (function : KFunction<T>) : FunctionWrapper<T>
-                = ArityN(function)
+            = ArityN(function)
 
         fun <T> on (function : suspend () -> T) : FunctionWrapper<T>
-                = ArityZero(function)
+            = ArityZero(function)
 
         fun <T, R> on (function : suspend (R) -> T)
-                = ArityOne(function, false)
+            = ArityOne(function, false)
 
         fun <T, R> on (function : suspend (R) -> T, hasReceiver: Boolean = false)
-                = ArityOne(function, hasReceiver)
+            = ArityOne(function, hasReceiver)
 
         fun <T, R, E> on (function : suspend (R, E) -> T, hasReceiver: Boolean = false)
-                = ArityTwo(function, hasReceiver)
+            = ArityTwo(function, hasReceiver)
 
         fun <T, R, E, W> on (function : suspend (R, E, W) -> T, hasReceiver: Boolean = false)
-                = ArityThree(function, hasReceiver)
+            = ArityThree(function, hasReceiver)
 
         fun <T, R, E, W, Q> on (function : suspend (R, E, W, Q) -> T, hasReceiver: Boolean = false)
-                = ArityFour(function, hasReceiver)
+            = ArityFour(function, hasReceiver)
 
         fun <T, R, E, W, Q, A> on (function : suspend (R, E, W, Q, A) -> T, hasReceiver: Boolean = false)
-                = ArityFive(function, hasReceiver)
+            = ArityFive(function, hasReceiver)
 
         fun <T, R, E, W, Q, A, S> on (function : suspend (R, E, W, Q, A, S) -> T, hasReceiver: Boolean = false)
-                = AritySix(function, hasReceiver)
+            = AritySix(function, hasReceiver)
 
         fun <T, R, E, W, Q, A, S, G> on (function : suspend (R, E, W, Q, A, S, G) -> T, hasReceiver: Boolean = false)
-                = AritySeven(function, hasReceiver)
+            = AritySeven(function, hasReceiver)
 
         fun <T, R, E, W, Q, A, S, G, H> on (function : suspend (R, E, W, Q, A, S, G, H) -> T, hasReceiver: Boolean = false)
-                = ArityEight(function, hasReceiver)
+            = ArityEight(function, hasReceiver)
 
         fun <T, R, E, W, Q, A, S, G, H, J> on (function : suspend (R, E, W, Q, A, S, G, H, J) -> T, hasReceiver: Boolean = false)
-                = ArityNine(function, hasReceiver)
+            = ArityNine(function, hasReceiver)
 
         fun <T, R, E, W, Q, A, S, G, H, J, K> on (function : suspend (R, E, W, Q, A, S, G, H, J, K) -> T, hasReceiver: Boolean = false)
-                = ArityTen(function, hasReceiver)
+            = ArityTen(function, hasReceiver)
 
         fun <T, R, E, W, Q, A, S, G, H, J, K, L> on (function : suspend (R, E, W, Q, A, S, G, H, J, K, L) -> T, hasReceiver: Boolean = false)
-                = ArityEleven(function, hasReceiver)
+            = ArityEleven(function, hasReceiver)
 
         fun <T, R, E, W, Q, A, S, G, H, J, K, L, M> on (function : suspend (R, E, W, Q, A, S, G, H, J, K, L, M) -> T, hasReceiver: Boolean = false)
-                = ArityTwelve(function, hasReceiver)
+            = ArityTwelve(function, hasReceiver)
 
         fun <T, R, E, W, Q, A, S, G, H, J, K, L, M, N> on (function : suspend (R, E, W, Q, A, S, G, H, J, K, L, M, N) -> T, hasReceiver: Boolean = false)
-                = ArityThirteen(function, hasReceiver)
+            = ArityThirteen(function, hasReceiver)
 
         fun <T, R, E, W, Q, A, S, G, H, J, K, L, M, N, O> on (function : suspend (R, E, W, Q, A, S, G, H, J, K, L, M, N, O) -> T, hasReceiver: Boolean = false)
-                = ArityFourteen(function, hasReceiver)
+            = ArityFourteen(function, hasReceiver)
 
         fun <T, R, E, W, Q, A, S, G, H, J, K, L, M, N, O, P> on (function : suspend (R, E, W, Q, A, S, G, H, J, K, L, M, N, O, P) -> T, hasReceiver: Boolean = false)
-                = ArityFifteen(function, hasReceiver)
+            = ArityFifteen(function, hasReceiver)
 
         fun <T, R, E, W, Q, A, S, G, H, J, K, L, M, N, O, P, U> on (function : suspend (R, E, W, Q, A, S, G, H, J, K, L, M, N, O, P, U) -> T, hasReceiver: Boolean = false)
-                = AritySixteen(function, hasReceiver)
+            = AritySixteen(function, hasReceiver)
 
         fun <T, R, E, W, Q, A, S, G, H, J, K, L, M, N, O, P, U, V> on (function : suspend (R, E, W, Q, A, S, G, H, J, K, L, M, N, O, P, U, V) -> T, hasReceiver: Boolean = false)
-                = AritySeventeen(function, hasReceiver)
+            = AritySeventeen(function, hasReceiver)
 
         fun <T, R, E, W, Q, A, S, G, H, J, K, L, M, N, O, P, U, V, X> on (function : suspend (R, E, W, Q, A, S, G, H, J, K, L, M, N, O, P, U, V, X) -> T, hasReceiver: Boolean = false)
-                = ArityEighteen(function, hasReceiver)
+            = ArityEighteen(function, hasReceiver)
 
         fun <T, R, E, W, Q, A, S, G, H, J, K, L, M, N, O, P, U, V, X, Y> on (function : suspend (R, E, W, Q, A, S, G, H, J, K, L, M, N, O, P, U, V, X, Y) -> T, hasReceiver: Boolean = false)
-                = ArityNineteen(function, hasReceiver)
+            = ArityNineteen(function, hasReceiver)
     }
 
     val kFunction: KFunction<T>

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/FunctionWrapper.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/FunctionWrapper.kt
@@ -30,37 +30,37 @@ interface FunctionWrapper <T> : Publisher {
                 = ArityN(function)
 
         fun <T> on (function : suspend () -> T) : FunctionWrapper<T>
-            = ArityZero(function)
+                = ArityZero(function)
 
         fun <T, R> on (function : suspend (R) -> T)
-            = ArityOne(function, false)
+                = ArityOne(function, false)
 
         fun <T, R> on (function : suspend (R) -> T, hasReceiver: Boolean = false)
-            = ArityOne(function, hasReceiver)
+                = ArityOne(function, hasReceiver)
 
         fun <T, R, E> on (function : suspend (R, E) -> T, hasReceiver: Boolean = false)
-            = ArityTwo(function, hasReceiver)
+                = ArityTwo(function, hasReceiver)
 
         fun <T, R, E, W> on (function : suspend (R, E, W) -> T, hasReceiver: Boolean = false)
-            = ArityThree(function, hasReceiver)
+                = ArityThree(function, hasReceiver)
 
         fun <T, R, E, W, Q> on (function : suspend (R, E, W, Q) -> T, hasReceiver: Boolean = false)
-            = ArityFour(function, hasReceiver)
+                = ArityFour(function, hasReceiver)
 
         fun <T, R, E, W, Q, A> on (function : suspend (R, E, W, Q, A) -> T, hasReceiver: Boolean = false)
-            = ArityFive(function, hasReceiver)
+                = ArityFive(function, hasReceiver)
 
         fun <T, R, E, W, Q, A, S> on (function : suspend (R, E, W, Q, A, S) -> T, hasReceiver: Boolean = false)
-            = AritySix(function, hasReceiver)
+                = AritySix(function, hasReceiver)
 
         fun <T, R, E, W, Q, A, S, G> on (function : suspend (R, E, W, Q, A, S, G) -> T, hasReceiver: Boolean = false)
-            = AritySeven(function, hasReceiver)
+                = AritySeven(function, hasReceiver)
 
         fun <T, R, E, W, Q, A, S, G, H> on (function : suspend (R, E, W, Q, A, S, G, H) -> T, hasReceiver: Boolean = false)
-            = ArityEight(function, hasReceiver)
+                = ArityEight(function, hasReceiver)
 
         fun <T, R, E, W, Q, A, S, G, H, J> on (function : suspend (R, E, W, Q, A, S, G, H, J) -> T, hasReceiver: Boolean = false)
-            = ArityNine(function, hasReceiver)
+                = ArityNine(function, hasReceiver)
 
         fun <T, R, E, W, Q, A, S, G, H, J, K> on (function : suspend (R, E, W, Q, A, S, G, H, J, K) -> T, hasReceiver: Boolean = false)
                 = ArityTen(function, hasReceiver)
@@ -548,7 +548,7 @@ interface FunctionWrapper <T> : Publisher {
             @Synchronized
             get() = implementation.reflect()!!
 
-        override fun arity(): Int = 9
+        override fun arity(): Int = 10
 
         override suspend fun invoke(vararg args: Any?): T? {
             if(args.size == arity()){
@@ -584,7 +584,7 @@ interface FunctionWrapper <T> : Publisher {
             @Synchronized
             get() = implementation.reflect()!!
 
-        override fun arity(): Int = 9
+        override fun arity(): Int = 11
 
         override suspend fun invoke(vararg args: Any?): T? {
             if(args.size == arity()){
@@ -620,7 +620,7 @@ interface FunctionWrapper <T> : Publisher {
             @Synchronized
             get() = implementation.reflect()!!
 
-        override fun arity(): Int = 9
+        override fun arity(): Int = 12
 
         override suspend fun invoke(vararg args: Any?): T? {
             if(args.size == arity()){
@@ -656,7 +656,7 @@ interface FunctionWrapper <T> : Publisher {
             @Synchronized
             get() = implementation.reflect()!!
 
-        override fun arity(): Int = 9
+        override fun arity(): Int = 13
 
         override suspend fun invoke(vararg args: Any?): T? {
             if(args.size == arity()){
@@ -692,7 +692,7 @@ interface FunctionWrapper <T> : Publisher {
             @Synchronized
             get() = implementation.reflect()!!
 
-        override fun arity(): Int = 9
+        override fun arity(): Int = 14
 
         override suspend fun invoke(vararg args: Any?): T? {
             if(args.size == arity()){
@@ -728,7 +728,7 @@ interface FunctionWrapper <T> : Publisher {
             @Synchronized
             get() = implementation.reflect()!!
 
-        override fun arity(): Int = 9
+        override fun arity(): Int = 15
 
         override suspend fun invoke(vararg args: Any?): T? {
             if(args.size == arity()){
@@ -764,7 +764,7 @@ interface FunctionWrapper <T> : Publisher {
             @Synchronized
             get() = implementation.reflect()!!
 
-        override fun arity(): Int = 9
+        override fun arity(): Int = 16
 
         override suspend fun invoke(vararg args: Any?): T? {
             if(args.size == arity()){
@@ -800,7 +800,7 @@ interface FunctionWrapper <T> : Publisher {
             @Synchronized
             get() = implementation.reflect()!!
 
-        override fun arity(): Int = 9
+        override fun arity(): Int = 17
 
         override suspend fun invoke(vararg args: Any?): T? {
             if(args.size == arity()){
@@ -836,7 +836,7 @@ interface FunctionWrapper <T> : Publisher {
             @Synchronized
             get() = implementation.reflect()!!
 
-        override fun arity(): Int = 9
+        override fun arity(): Int = 18
 
         override suspend fun invoke(vararg args: Any?): T? {
             if(args.size == arity()){
@@ -872,7 +872,7 @@ interface FunctionWrapper <T> : Publisher {
             @Synchronized
             get() = implementation.reflect()!!
 
-        override fun arity(): Int = 9
+        override fun arity(): Int = 19
 
         override suspend fun invoke(vararg args: Any?): T? {
             if(args.size == arity()){


### PR DESCRIPTION
The maximum function argument for the query resolver was 9.
However, there were cases where that was not enough, so I added it.

example

```
query ("test") {
    description = "test"
    resolver {
        arg1:String?, arg2:String?, arg3:String?, arg4:String?, arg5:String?, arg6:String?, arg7:String?,
            arg8:String?, arg9:String?, arg10:String?, arg11:String?,arg12:String?,arg13:String?,arg14:String?,
            arg15:String?, arg16:String?, arg17:String?, arg18:String?, arg19:String? ->

        true
    }
}
```