### PR TITLE
fix(dsl:input) - handle optional args

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/InputValuesDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/InputValuesDSL.kt
@@ -9,13 +9,13 @@ class InputValuesDSL {
 
     val inputValues = mutableListOf<InputValueDSL<*>>()
 
-    fun <T : Any> arg(kClass: KClass<T>, kType: KType? = null, block : InputValueDSL<T>.() -> Unit){
+    fun <T : Any> arg(kClass: KClass<T>, kType: KType? = null, block: InputValueDSL<T>.() -> Unit) {
         inputValues.add(InputValueDSL(kClass, kType).apply(block))
     }
 
     @OptIn(ExperimentalStdlibApi::class)
-    inline fun <reified T : Any> arg(noinline block : InputValueDSL<T>.() -> Unit){
-        arg(T::class, typeOf<T>(), block)
+    inline fun <reified T : Any> arg(optional: Boolean = false, noinline block: InputValueDSL<T>.() -> Unit) {
+        val kType = if (optional) typeOf<T?>() else typeOf<T>()
+        arg(T::class, kType, block)
     }
-
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
@@ -152,6 +152,28 @@ abstract class BaseSchemaTest {
                 }
             }
         }
+        query("actorsByTags") {
+            description = "testing ktype & jvm erasure problems"
+            resolver { tags: List<String> ->
+                mutableListOf(bradPitt, morganFreeman, kevinSpacey, tomHardy)
+            }
+        }
+        query("actorsByTagsOptional") {
+            description = "testing ktype & jvm erasure problems"
+            resolver { tags: List<String>? ->
+                mutableListOf(bradPitt, morganFreeman, kevinSpacey, tomHardy)
+            }.withArgs {
+                arg<List<String>>(optional = true) { name = "tags"; defaultValue = emptyList() }
+            }
+        }
+        query("actorsByTagsNullable") {
+            description = "testing ktype & jvm erasure problems"
+            resolver { tags: List<String>? ->
+                mutableListOf(bradPitt, morganFreeman, kevinSpacey, tomHardy)
+            }.withArgs {
+                arg<List<String>>(optional = true) { name = "tags"; defaultValue = null }
+            }
+        }
         query("filmByRank") {
             description = "ranked films"
             resolver { rank: Int -> when(rank){
@@ -242,6 +264,20 @@ abstract class BaseSchemaTest {
                     }
                 }
             }
+
+            property<String>("pictureWithArgs") {
+                resolver { actor, big : Boolean? ->
+                    val actorName = actor.name.replace(' ', '_')
+                    if(big == true){
+                        "http://picture.server/pic/$actorName?big=true"
+                    } else {
+                        "http://picture.server/pic/$actorName?big=false"
+                    }
+                }.withArgs {
+                    arg<Boolean>(optional = true) { name = "big"; description = "big or small picture" }
+                }
+            }
+
             unionProperty("favourite") {
                 returnType = favouriteID
                 resolver { actor -> when(actor){

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/QueryTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/QueryTest.kt
@@ -147,6 +147,33 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
+    fun `query extension property with optional annotated argument`() {
+        val map = execute("{actors{name, pictureWithArgs}}")
+        for(i in 0..4){
+            val name = map.extract<String>("data/actors[$i]/name").replace(' ', '_')
+            assertThat(map.extract<String>("data/actors[$i]/pictureWithArgs"), equalTo("http://picture.server/pic/$name?big=false"))
+        }
+    }
+
+    @Test
+    fun `query with mandatory generic input type`() {
+        val map = execute("""{actorsByTags(tags: ["1", "2", "3"]){name}}""")
+        assertNoErrors(map)
+    }
+
+    @Test
+    fun `query with optional generic input type`() {
+        val map = execute("{actorsByTagsOptional{name}}")
+        assertNoErrors(map)
+    }
+
+    @Test
+    fun `query with nulabble generic input type`() {
+        val map = execute("{actorsByTagsNullable{name}}")
+        assertNoErrors(map)
+    }
+
+    @Test
     fun `query with transformed property`(){
         val map = execute("{scenario{id, content(uppercase: false)}}")
         assertThat(map.extract<String>("data/scenario/content"), equalTo("Very long scenario"))


### PR DESCRIPTION
fix a bug where optional-nullable input types caused `Missing value for non-nullable argument <argument name> on the field <matching field>` (root cause is related to [validation function](https://github.com/aPureBase/KGraphQL/blob/main/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Validation.kt#L46))

previous `args()` always returned a defined non-nullable type, making input.type.kind non-optional 