### PR TITLE
Allow users to provide custom generic type resolver

### DIFF
--- a/docs/content/Reference/configuration.md
+++ b/docs/content/Reference/configuration.md
@@ -9,7 +9,7 @@ KGraphQL schema allows configuration of following properties:
 |acceptSingleValueAsArray | Schema accepts single argument values as singleton list | `true`
 | coroutineDispatcher | Schema is using CoroutineDispatcher from this property | [CommonPool](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/src/main/kotlin/kotlinx/coroutines/experimental/CommonPool.kt) |
 | executor |  | [Executor.Parallel](https://github.com/aPureBase/KGraphQL/blob/master/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/Executor.kt) |
-
+| genericTypeResolver | Schema is using generic type resolver from this property | [GenericTypeResolver.DEFAULT](https://github.com/aPureBase/KGraphQL/blob/master/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/GenericTypeResolver.kt) |
 
 *Example*
 

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/configuration/SchemaConfiguration.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/configuration/SchemaConfiguration.kt
@@ -1,6 +1,7 @@
 package com.apurebase.kgraphql.configuration
 
 import com.apurebase.kgraphql.schema.execution.Executor
+import com.apurebase.kgraphql.schema.execution.GenericTypeResolver
 import com.fasterxml.jackson.databind.ObjectMapper
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlin.reflect.KClass
@@ -20,7 +21,9 @@ data class SchemaConfiguration(
         val executor: Executor,
         val timeout: Long?,
         val introspection: Boolean = true,
-        val plugins: MutableMap<KClass<*>, Any>
+        val plugins: MutableMap<KClass<*>, Any>,
+
+        val genericTypeResolver: GenericTypeResolver,
 ) {
         @Suppress("UNCHECKED_CAST")
         operator fun <T: Any> get(type: KClass<T>) = plugins[type] as T?

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/SchemaConfigurationDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/SchemaConfigurationDSL.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.apurebase.kgraphql.configuration.SchemaConfiguration
 import com.apurebase.kgraphql.schema.execution.Executor
+import com.apurebase.kgraphql.schema.execution.GenericTypeResolver
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlin.reflect.KClass
@@ -21,6 +22,7 @@ open class SchemaConfigurationDSL {
     var executor: Executor = Executor.Parallel
     var timeout: Long? = null
     var introspection: Boolean = true
+    var genericTypeResolver: GenericTypeResolver = GenericTypeResolver.DEFAULT
 
     private val plugins: MutableMap<KClass<*>, Any> = mutableMapOf()
 
@@ -35,16 +37,17 @@ open class SchemaConfigurationDSL {
     internal fun build(): SchemaConfiguration {
         objectMapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, acceptSingleValueAsArray)
         return SchemaConfiguration(
-            useCachingDocumentParser,
-            documentParserCacheMaximumSize,
-            objectMapper,
-            useDefaultPrettyPrinter,
-            coroutineDispatcher,
-            wrapErrors,
-            executor,
-            timeout,
-            introspection,
-            plugins
+            useCachingDocumentParser = useCachingDocumentParser,
+            documentParserCacheMaximumSize = documentParserCacheMaximumSize,
+            objectMapper = objectMapper,
+            useDefaultPrettyPrinter = useDefaultPrettyPrinter,
+            coroutineDispatcher = coroutineDispatcher,
+            wrapErrors = wrapErrors,
+            executor = executor,
+            timeout = timeout,
+            introspection = introspection,
+            plugins = plugins,
+            genericTypeResolver = genericTypeResolver,
         )
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/GenericTypeResolver.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/GenericTypeResolver.kt
@@ -1,0 +1,30 @@
+package com.apurebase.kgraphql.schema.execution
+
+import com.apurebase.kgraphql.schema.SchemaException
+import java.util.*
+import kotlin.reflect.KType
+
+/**
+ * A generic type resolver takes values that are wrapped in classes like {@link java.util.Optional} / {@link java.util.OptionalInt} etc..
+ * and returns value from them.  You can provide your own implementation if you have your own specific
+ * holder classes.
+ */
+interface GenericTypeResolver {
+
+    fun unbox(obj: Any): Any?
+
+    fun resolveMonad(type: KType): KType
+
+    companion object {
+        val DEFAULT = DefaultGenericTypeResolver()
+    }
+}
+
+open class DefaultGenericTypeResolver : GenericTypeResolver {
+
+    override fun unbox(obj: Any): Any? = obj
+
+    override fun resolveMonad(type: KType): KType =
+        throw SchemaException("Could not resolve resulting type for monad $type. " +
+                "Please provide custom GenericTypeResolver to KGraphQL configuration to register your generic types")
+}

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
@@ -165,7 +165,8 @@ class SchemaCompilation(
             kType.jvmErasure == Context::class && typeCategory == TypeCategory.INPUT -> contextType
             kType.jvmErasure == Execution.Node::class && typeCategory == TypeCategory.INPUT -> executionType
             kType.jvmErasure == Context::class && typeCategory == TypeCategory.QUERY -> throw SchemaException("Context type cannot be part of schema")
-            kType.arguments.isNotEmpty() -> throw SchemaException("Generic types are not supported by GraphQL, found $kType")
+            kType.arguments.isNotEmpty() -> configuration.genericTypeResolver.resolveMonad(kType)
+                .let { handlePossiblyWrappedType(it, typeCategory) }
             kType.jvmErasure.isSealed -> TypeDef.Union(
                 name = kType.jvmErasure.simpleName!!,
                 members = kType.jvmErasure.sealedSubclasses.toSet(),


### PR DESCRIPTION
Allow users to add their custom Generic Type Resolver in order to use generic types in schema.

The idea is based on graphql-java implementation:
https://javadoc.io/static/com.graphql-java/graphql-java/14.0/graphql/execution/ValueUnboxer.html

example 
```kotlin
data class ClassWithOptionalField(val value: Optional<Int>)

val schema = defaultSchema {
    configure {
        genericTypeResolver = object : DefaultGenericTypeResolver() {
            override fun unbox(obj: Any) = when (obj) {
                is Optional<*> -> obj.orElse(null)
                else -> super.unbox(obj)
            }

            override fun resolveMonad(type: KType): KType = when {
                type.jvmErasure.isSubclassOf(Optional::class) ->
                    type.arguments.firstOrNull()?.type?.withNullability(true)
                        ?: throw SchemaException("Could not get the type of the first argument for the type $type")

                else -> super.resolveMonad(type)
            }
        }
    }

    type<ClassWithOptionalField>()
    query("data1") {
        resolver<ClassWithOptionalField> {
            ClassWithOptionalField(Optional.ofNullable(42))
        }
    }
    query("data2") {
        resolver<ClassWithOptionalField> {
            ClassWithOptionalField(Optional.ofNullable(null))
        }
    }
}

assertThat(
    deserialize(schema.executeBlocking("{data1 {value}}")).extract<String>("data/data1/value"),
    equalTo(42)
)
assertThat(
    deserialize(schema.executeBlocking("{data2 {value}}")).extract<String>("data/data2/value"),
    equalTo(null)
)
```