### PR TITLE
Use operationName if provided by GraphQLRequest (fixes #81)

### DIFF
--- a/kgraphql-ktor/src/main/kotlin/com/apurebase/kgraphql/KtorFeature.kt
+++ b/kgraphql-ktor/src/main/kotlin/com/apurebase/kgraphql/KtorFeature.kt
@@ -3,24 +3,19 @@ package com.apurebase.kgraphql
 import com.apurebase.kgraphql.schema.Schema
 import com.apurebase.kgraphql.schema.dsl.SchemaBuilder
 import com.apurebase.kgraphql.schema.dsl.SchemaConfigurationDSL
-import io.ktor.server.application.*
 import io.ktor.http.*
+import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
-import io.ktor.server.application.Application
-import io.ktor.server.application.ApplicationCall
-import io.ktor.server.application.call
-import io.ktor.server.application.install
 import io.ktor.server.routing.*
 import io.ktor.util.*
-import java.nio.charset.Charset
 import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.json.*
 import kotlinx.serialization.json.Json.Default.decodeFromString
 
 class GraphQL(val schema: Schema) {
 
-    class Configuration: SchemaConfigurationDSL() {
+    class Configuration : SchemaConfigurationDSL() {
         fun schema(block: SchemaBuilder.() -> Unit) {
             schemaBlock = block
         }
@@ -47,7 +42,7 @@ class GraphQL(val schema: Schema) {
     }
 
 
-    companion object Feature: Plugin<Application, Configuration, GraphQL> {
+    companion object Feature : Plugin<Application, Configuration, GraphQL> {
         override val key = AttributeKey<GraphQL>("KGraphQL")
 
         private val rootFeature = FeatureInstance("KGraphQL")
@@ -57,7 +52,7 @@ class GraphQL(val schema: Schema) {
         }
     }
 
-    class FeatureInstance(featureKey: String = "KGraphQL"): Plugin<Application, Configuration, GraphQL> {
+    class FeatureInstance(featureKey: String = "KGraphQL") : Plugin<Application, Configuration, GraphQL> {
 
         override val key = AttributeKey<GraphQL>(featureKey)
 
@@ -78,7 +73,12 @@ class GraphQL(val schema: Schema) {
                                 config.contextSetup?.invoke(this, call)
                             }
                             val result =
-                                schema.execute(request.query, request.operationName, request.variables.toString(), ctx)
+                                schema.execute(
+                                    request.query,
+                                    request.variables.toString(),
+                                    ctx,
+                                    operationName = request.operationName
+                                )
                             call.respondText(result, contentType = ContentType.Application.Json)
                         }
                         if (config.playground) get {

--- a/kgraphql-ktor/src/main/kotlin/com/apurebase/kgraphql/KtorFeature.kt
+++ b/kgraphql-ktor/src/main/kotlin/com/apurebase/kgraphql/KtorFeature.kt
@@ -77,12 +77,15 @@ class GraphQL(val schema: Schema) {
                             val ctx = context {
                                 config.contextSetup?.invoke(this, call)
                             }
-                            val result = schema.execute(request.query, request.variables.toString(), ctx)
+                            val result =
+                                schema.execute(request.query, request.operationName, request.variables.toString(), ctx)
                             call.respondText(result, contentType = ContentType.Application.Json)
                         }
                         if (config.playground) get {
                             @Suppress("RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
-                            val playgroundHtml = KtorGraphQLConfiguration::class.java.classLoader.getResource("playground.html").readBytes()
+                            val playgroundHtml =
+                                KtorGraphQLConfiguration::class.java.classLoader.getResource("playground.html")
+                                    .readBytes()
                             call.respondBytes(playgroundHtml, contentType = ContentType.Text.Html)
                         }
                     }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/DefaultSchema.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/DefaultSchema.kt
@@ -4,11 +4,12 @@ import com.apurebase.kgraphql.Context
 import com.apurebase.kgraphql.GraphQLError
 import com.apurebase.kgraphql.configuration.SchemaConfiguration
 import com.apurebase.kgraphql.request.CachingDocumentParser
-import com.apurebase.kgraphql.request.VariablesJson
-import com.apurebase.kgraphql.schema.introspection.__Schema
 import com.apurebase.kgraphql.request.Parser
+import com.apurebase.kgraphql.request.VariablesJson
 import com.apurebase.kgraphql.schema.execution.*
-import com.apurebase.kgraphql.schema.execution.Executor.*
+import com.apurebase.kgraphql.schema.execution.Executor.DataLoaderPrepared
+import com.apurebase.kgraphql.schema.execution.Executor.Parallel
+import com.apurebase.kgraphql.schema.introspection.__Schema
 import com.apurebase.kgraphql.schema.model.ast.NameNode
 import com.apurebase.kgraphql.schema.structure.LookupSchema
 import com.apurebase.kgraphql.schema.structure.RequestInterpreter
@@ -41,10 +42,10 @@ class DefaultSchema(
 
     override suspend fun execute(
         request: String,
-        operationName: String?,
         variables: String?,
         context: Context,
-        options: ExecutionOptions
+        options: ExecutionOptions,
+        operationName: String?,
     ): String = coroutineScope {
         val parsedVariables = variables
             ?.let { VariablesJson.Defined(configuration.objectMapper, variables) }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/Schema.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/Schema.kt
@@ -12,15 +12,17 @@ interface Schema : __Schema {
 
     suspend fun execute(
         @Language("graphql") request: String,
+        operationName: String? = null,
         variables: String? = null,
         context: Context = Context(emptyMap()),
         options: ExecutionOptions = ExecutionOptions()
-    ) : String
+    ): String
 
     fun executeBlocking(
         @Language("graphql") request: String,
+        operationName: String? = null,
         variables: String? = null,
         context: Context = Context(emptyMap()),
         options: ExecutionOptions = ExecutionOptions()
-    ) = runBlocking { execute(request, variables, context, options) }
+    ) = runBlocking { execute(request, operationName, variables, context, options) }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/Schema.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/Schema.kt
@@ -12,17 +12,17 @@ interface Schema : __Schema {
 
     suspend fun execute(
         @Language("graphql") request: String,
-        operationName: String? = null,
         variables: String? = null,
         context: Context = Context(emptyMap()),
-        options: ExecutionOptions = ExecutionOptions()
+        options: ExecutionOptions = ExecutionOptions(),
+        operationName: String? = null
     ): String
 
     fun executeBlocking(
         @Language("graphql") request: String,
-        operationName: String? = null,
         variables: String? = null,
         context: Context = Context(emptyMap()),
-        options: ExecutionOptions = ExecutionOptions()
-    ) = runBlocking { execute(request, operationName, variables, context, options) }
+        options: ExecutionOptions = ExecutionOptions(),
+        operationName: String? = null,
+    ) = runBlocking { execute(request, variables, context, options, operationName) }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/SchemaProxy.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/SchemaProxy.kt
@@ -51,11 +51,11 @@ class SchemaProxy(
 
     override suspend fun execute(
         request: String,
-        operationName: String?,
         variables: String?,
         context: Context,
-        options: ExecutionOptions
+        options: ExecutionOptions,
+        operationName: String?
     ): String {
-        return getProxied().execute(request, operationName, variables, context, options)
+        return getProxied().execute(request, variables, context, options, operationName)
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/SchemaProxy.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/SchemaProxy.kt
@@ -11,8 +11,8 @@ import kotlin.reflect.KType
 
 class SchemaProxy(
     override val configuration: SchemaConfiguration,
-    var proxiedSchema : LookupSchema? = null
-): LookupSchema {
+    var proxiedSchema: LookupSchema? = null
+) : LookupSchema {
 
     companion object {
         const val ILLEGAL_STATE_MESSAGE = "Missing proxied __Schema instance"
@@ -49,7 +49,13 @@ class SchemaProxy(
 
     override fun inputTypeByName(name: String): Type? = inputTypeByName(name)
 
-    override suspend fun execute(request: String, variables: String?, context: Context, options: ExecutionOptions): String {
-        return getProxied().execute(request, variables, context, options)
+    override suspend fun execute(
+        request: String,
+        operationName: String?,
+        variables: String?,
+        context: Context,
+        options: ExecutionOptions
+    ): String {
+        return getProxied().execute(request, operationName, variables, context, options)
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/RequestInterpreter.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/RequestInterpreter.kt
@@ -30,7 +30,7 @@ class RequestInterpreter(val schemaModel: SchemaModel) {
         // prevent stack overflow
         private val fragmentsStack = Stack<String>()
         fun get(node: FragmentSpreadNode): Execution.Fragment? {
-            if(fragmentsStack.contains(node.name.value)) throw GraphQLError(
+            if (fragmentsStack.contains(node.name.value)) throw GraphQLError(
                 "Fragment spread circular references are not allowed",
                 node
             )
@@ -46,7 +46,12 @@ class RequestInterpreter(val schemaModel: SchemaModel) {
         }
     }
 
-    fun createExecutionPlan(document: DocumentNode, variables: VariablesJson, options: ExecutionOptions): ExecutionPlan {
+    fun createExecutionPlan(
+        document: DocumentNode,
+        requestedOperationName: String?,
+        variables: VariablesJson,
+        options: ExecutionOptions
+    ): ExecutionPlan {
         val test = document.definitions.filterIsInstance<ExecutableDefinitionNode>()
 
         val operation = test.filterIsInstance<OperationDefinitionNode>().let { operations ->
@@ -58,8 +63,10 @@ class RequestInterpreter(val schemaModel: SchemaModel) {
                         if (it.size != operations.size) throw GraphQLError("anonymous operation must be the only defined operation")
                     }.joinToString(prefix = "[", postfix = "]")
 
-                    val operationName = variables.get(String::class, String::class.starProjectedType, OPERATION_NAME_PARAM)
-                        ?: throw GraphQLError("Must provide an operation name from: $operationNamesFound")
+                    val operationName = requestedOperationName ?: (
+                        variables.get(String::class, String::class.starProjectedType, OPERATION_NAME_PARAM)
+                            ?: throw GraphQLError("Must provide an operation name from: $operationNamesFound")
+                        )
 
                     operations.firstOrNull { it.name?.value == operationName }
                         ?: throw GraphQLError("Must provide an operation name from: $operationNamesFound, found $operationName")
@@ -69,8 +76,11 @@ class RequestInterpreter(val schemaModel: SchemaModel) {
 
         val root = when (operation.operation) {
             OperationTypeNode.QUERY -> schemaModel.query
-            OperationTypeNode.MUTATION -> schemaModel.mutation ?: throw GraphQLError("Mutations are not supported on this schema")
-            OperationTypeNode.SUBSCRIPTION -> schemaModel.subscription ?: throw GraphQLError("Subscriptions are not supported on this schema")
+            OperationTypeNode.MUTATION -> schemaModel.mutation
+                ?: throw GraphQLError("Mutations are not supported on this schema")
+
+            OperationTypeNode.SUBSCRIPTION -> schemaModel.subscription
+                ?: throw GraphQLError("Subscriptions are not supported on this schema")
         }
 
         val fragmentDefinitionNode = test.filterIsInstance<FragmentDefinitionNode>()
@@ -79,7 +89,7 @@ class RequestInterpreter(val schemaModel: SchemaModel) {
             val name = fragmentDef.name!!.value
 
             if (fragmentDefinitionNode.count { it.name!!.value == name } > 1) {
-                throw GraphQLError("There can be only one fragment named $name.", fragmentDef )
+                throw GraphQLError("There can be only one fragment named $name.", fragmentDef)
             }
 
             name to (type to fragmentDef.selectionSet)
@@ -100,7 +110,12 @@ class RequestInterpreter(val schemaModel: SchemaModel) {
     private fun handleReturnType(ctx: InterpreterContext, type: Type, requestNode: FieldNode) =
         handleReturnType(ctx, type, requestNode.selectionSet, requestNode.name)
 
-    private fun handleReturnType(ctx: InterpreterContext, type: Type, selectionSet: SelectionSetNode?, propertyName: NameNode? = null): List<Execution> {
+    private fun handleReturnType(
+        ctx: InterpreterContext,
+        type: Type,
+        selectionSet: SelectionSetNode?,
+        propertyName: NameNode? = null
+    ): List<Execution> {
         val children = mutableListOf<Execution>()
 
         if (!selectionSet?.selections.isNullOrEmpty()) {
@@ -120,15 +135,22 @@ class RequestInterpreter(val schemaModel: SchemaModel) {
     private fun handleReturnTypeChildOrFragment(node: SelectionNode, returnType: Type, ctx: InterpreterContext) =
         returnType.unwrapped().handleSelectionFieldOrFragment(node, ctx)
 
-    private fun findFragmentType(fragment: FragmentNode, ctx: InterpreterContext, enclosingType: Type): Execution.Fragment = when(fragment) {
+    private fun findFragmentType(
+        fragment: FragmentNode,
+        ctx: InterpreterContext,
+        enclosingType: Type
+    ): Execution.Fragment = when (fragment) {
         is FragmentSpreadNode -> {
             ctx.get(fragment) ?: throw throwUnknownFragmentTypeEx(fragment)
         }
+
         is InlineFragmentNode -> {
-            val type =if (fragment.directives?.isNotEmpty() == true) {
+            val type = if (fragment.directives?.isNotEmpty() == true) {
                 enclosingType
             } else {
-                schemaModel.queryTypesByName[fragment.typeCondition?.name?.value] ?: throw throwUnknownFragmentTypeEx(fragment)
+                schemaModel.queryTypesByName[fragment.typeCondition?.name?.value] ?: throw throwUnknownFragmentTypeEx(
+                    fragment
+                )
             }
             Execution.Fragment(
                 selectionNode = fragment,
@@ -139,17 +161,23 @@ class RequestInterpreter(val schemaModel: SchemaModel) {
         }
     }
 
-    private fun Type.handleSelectionFieldOrFragment(node: SelectionNode, ctx: InterpreterContext): Execution = when (node) {
-        is FragmentNode -> findFragmentType(node, ctx, this)
-        is FieldNode -> handleSelection(node, ctx)
-    }
+    private fun Type.handleSelectionFieldOrFragment(node: SelectionNode, ctx: InterpreterContext): Execution =
+        when (node) {
+            is FragmentNode -> findFragmentType(node, ctx, this)
+            is FieldNode -> handleSelection(node, ctx)
+        }
 
-    private fun Type.handleSelection(node: FieldNode, ctx: InterpreterContext, variables: List<VariableDefinitionNode>? = null): Execution.Node {
+    private fun Type.handleSelection(
+        node: FieldNode,
+        ctx: InterpreterContext,
+        variables: List<VariableDefinitionNode>? = null
+    ): Execution.Node {
         return when (val field = this[node.name.value]) {
             null -> throw GraphQLError(
                 "Property ${node.name.value} on $name does not exist",
                 node
             )
+
             is Field.Union<*> -> handleUnion(field, node, ctx)
             else -> {
                 validatePropertyArguments(this, field, node)
@@ -168,31 +196,40 @@ class RequestInterpreter(val schemaModel: SchemaModel) {
         }
     }
 
-    private fun <T> handleUnion(field: Field.Union<T>, selectionNode: FieldNode, ctx: InterpreterContext): Execution.Union {
+    private fun <T> handleUnion(
+        field: Field.Union<T>,
+        selectionNode: FieldNode,
+        ctx: InterpreterContext
+    ): Execution.Union {
         validateUnionRequest(field, selectionNode)
 
-        val unionMembersChildren: Map<Type, List<Execution>> = field.returnType.possibleTypes.associateWith { possibleType ->
-            val selections = selectionNode.selectionSet?.selections
+        val unionMembersChildren: Map<Type, List<Execution>> =
+            field.returnType.possibleTypes.associateWith { possibleType ->
+                val selections = selectionNode.selectionSet?.selections
 
-            val a = selections?.filterIsInstance<FragmentSpreadNode>()?.firstOrNull {
-                ctx.fragments[it.name.value]?.first?.name == possibleType.name
+                val a = selections?.filterIsInstance<FragmentSpreadNode>()?.firstOrNull {
+                    ctx.fragments[it.name.value]?.first?.name == possibleType.name
+                }
+
+                if (a != null) return@associateWith handleReturnType(
+                    ctx,
+                    possibleType,
+                    ctx.fragments.getValue(a.name.value).second
+                )
+
+                val b = selections?.filterIsInstance<InlineFragmentNode>()?.find {
+                    possibleType.name == it.typeCondition?.name?.value
+                }
+
+                if (b != null) return@associateWith handleReturnType(ctx, possibleType, b.selectionSet)
+
+                throw GraphQLError(
+                    "Missing type argument for type ${possibleType.name}",
+                    selectionNode
+                )
             }
 
-            if (a != null) return@associateWith handleReturnType(ctx, possibleType, ctx.fragments.getValue(a.name.value).second)
-
-            val b = selections?.filterIsInstance<InlineFragmentNode>()?.find {
-                possibleType.name == it.typeCondition?.name?.value
-            }
-
-            if (b != null) return@associateWith handleReturnType(ctx, possibleType, b.selectionSet)
-
-            throw GraphQLError(
-                "Missing type argument for type ${possibleType.name}",
-                selectionNode
-            )
-        }
-
-        return Execution.Union (
+        return Execution.Union(
             node = selectionNode,
             unionField = field,
             memberChildren = unionMembersChildren,


### PR DESCRIPTION
Currently KGraphQL can't handle GraphQL documents with more than one operation unless the operation name is provided as a variable, but usually the operation name - if needed - is provided as a part of the request (see kgraphl-ktor for example).

These changes incorporate this behavior and pass the requested operation name through to the executor.